### PR TITLE
chore: prepare for Kubernetes 1.36 upgrade

### DIFF
--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
@@ -11,8 +11,8 @@ spec:
   interval: 1h
   values:
     cdi:
-      staticPath: /var/cdi/static
-      dynamicPath: /var/cdi/dynamic
+      staticPath: /run/cdi
+      dynamicPath: /run/cdi
     kubeletPlugin:
       healthMonitoring:
         enabled: false

--- a/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
@@ -5,6 +5,6 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
-  - ./mutatingadmissionpolicy.yaml
+  # - ./mutatingadmissionpolicy.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -33,7 +33,6 @@ machine:
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
         [plugins."io.containerd.cri.v1.runtime"]
-          cdi_spec_dirs = ["/var/cdi/static", "/var/cdi/dynamic"]
           device_ownership_from_security_context = true
     - op: overwrite
       path: /etc/nfsmount.conf
@@ -137,8 +136,6 @@ cluster:
     disablePodSecurityPolicy: true
     extraArgs:
       enable-aggregator-routing: "true"
-      feature-gates: MutatingAdmissionPolicy=true
-      runtime-config: admissionregistration.k8s.io/v1beta1=true
     image: registry.k8s.io/kube-apiserver:v1.35.4
   controllerManager:
     extraArgs:


### PR DESCRIPTION
## Summary
- Disable MutatingAdmissionPolicy resources (comment out from kustomization)
- Remove `MutatingAdmissionPolicy=true` feature-gate and `admissionregistration.k8s.io/v1beta1` runtime-config from kube-apiserver args
- Remove custom `cdi_spec_dirs` from containerd config and update intel-gpu CDI paths to `/run/cdi` (talos defaults)

## Rollout
1. Merge this PR and apply the machineconfig
2. Merge Renovate PR #5671 to bump Kubernetes to v1.36.0
3. After the cluster is running 1.36, re-enable MAPs with `v1` apiVersion


Made with [Cursor](https://cursor.com)