### PR TITLE
chore: migrate to v1 MAPs

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
@@ -5,6 +5,6 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
-  # - ./mutatingadmissionpolicy.yaml
+  - ./mutatingadmissionpolicy.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-jitter
 spec:
   policyName: volsync-mover-jitter
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-jitter


### PR DESCRIPTION
## Summary
- Re-enable MutatingAdmissionPolicy resources (uncomment from kustomization)
- Update apiVersion from `v1beta1` to `v1` (GA in Kubernetes 1.36)
- Update schema URLs to v1.36.0

Follows up on #5703 and #5671.

Made with [Cursor](https://cursor.com)