### PR TITLE
chore: use MAP to rewrite grafana image to mirror.gcr.io

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./grafanadatasource.yaml
   - ./grafana.yaml
+  - ./mutatingadmissionpolicy.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/grafana/instance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/observability/grafana/instance/mutatingadmissionpolicy.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: grafana-image-mirror
+spec:
+  policyName: grafana-image-mirror
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: grafana-image-mirror
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+  matchConditions:
+    - name: is-grafana-deployment
+      expression: >-
+        object.metadata.name == "grafana-deployment"
+    - name: has-docker-io-grafana-image
+      expression: >-
+        object.spec.template.spec.containers.exists(c,
+          c.image.startsWith("docker.io/grafana/")
+        )
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          [
+            JSONPatch{
+              op: "replace",
+              path: "/spec/template/spec/containers/0/image",
+              value: "mirror.gcr.io/grafana/" + object.spec.template.spec.containers[0].image.replace("docker.io/grafana/", "")
+            }
+          ]


### PR DESCRIPTION
## Summary
- Adds a MutatingAdmissionPolicy that intercepts grafana deployments and rewrites `docker.io/grafana/*` images to `mirror.gcr.io/grafana/*`
- Avoids Docker Hub rate limits by pulling from Google's container mirror

## Context
Following the same pattern from [onedr0p/home-ops@df8685bc3](https://github.com/onedr0p/home-ops/commit/df8685bc3).


Made with [Cursor](https://cursor.com)