### PR TITLE
fix: add HPAScaleToZero feature gate to controller manager

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -141,6 +141,7 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+      feature-gates: HPAScaleToZero=true
     image: registry.k8s.io/kube-controller-manager:v1.36.0
   coreDNS:
     disabled: true


### PR DESCRIPTION
## Summary
- Adds `feature-gates: HPAScaleToZero=true` to `controllerManager.extraArgs` in the talos machineconfig
- The HPA controller lives in the controller manager, so it needs this gate to allow scaling to zero replicas

## Context
Follow-up to #5728 — the feature gate was only added to the API server but the controller manager also needs it.

ref: https://github.com/buroa/k8s-gitops/blob/main/talos/machineconfig.yaml.j2#L126


Made with [Cursor](https://cursor.com)