### PR TITLE
chore(grafana): rename dashboard selector label

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -23,7 +23,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -38,7 +38,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -53,7 +53,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -25,7 +25,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       mode: GrafanaOperator
       grafanaOperator:
         matchLabels:
-          grafana.internal/instance: grafana
+          dashboards: grafana
     service:
       registry:
         hostPort: 29999

--- a/kubernetes/apps/longhorn-system/longhorn/app/grafanadashboard.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/network/cloudflare-tunnel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/network/envoy-gateway/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -23,7 +23,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -38,7 +38,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -53,7 +53,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -68,7 +68,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/o11y/fluent-bit/app/grafanadashboard.yaml
+++ b/kubernetes/apps/o11y/fluent-bit/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/o11y/grafana/app/grafanadashboard.yaml
+++ b/kubernetes/apps/o11y/grafana/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/o11y/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/grafana.yaml
@@ -5,7 +5,7 @@ kind: Grafana
 metadata:
   name: grafana
   labels:
-    grafana.internal/instance: grafana
+    dashboards: grafana
 spec:
   config:
     analytics:

--- a/kubernetes/apps/o11y/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/grafanadatasource.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasource:
     type: prometheus
     name: prometheus
@@ -23,7 +23,7 @@ metadata:
 spec:
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasource:
     type: alertmanager
     name: alertmanager

--- a/kubernetes/apps/o11y/grafana/instance/servicemonitor.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/servicemonitor.yaml
@@ -15,4 +15,4 @@ spec:
       - o11y
   selector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/grafanadashboard.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -23,7 +23,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -38,7 +38,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -53,7 +53,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -68,7 +68,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -83,7 +83,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -98,7 +98,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -113,7 +113,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -128,7 +128,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
         dashboardsConfigMapRefEnabled: true
         folder: o11y
         matchLabels:
-          grafana.internal/instance: grafana
+          dashboards: grafana
     additionalPrometheusRulesMap:
       dockerhub-rules:
         groups:

--- a/kubernetes/apps/o11y/unpoller/app/grafanadashboard.yaml
+++ b/kubernetes/apps/o11y/unpoller/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -23,7 +23,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -38,7 +38,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -53,7 +53,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
@@ -68,7 +68,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/o11y/victoria-logs/app/grafanadashboard.yaml
+++ b/kubernetes/apps/o11y/victoria-logs/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS

--- a/kubernetes/apps/volsync-system/volsync/app/grafanadashboard.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/grafanadashboard.yaml
@@ -8,7 +8,7 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      grafana.internal/instance: grafana
+      dashboards: grafana
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS


### PR DESCRIPTION
## Summary
- Replace `grafana.internal/instance: grafana` with `dashboards: grafana` across all `GrafanaDashboard`, `GrafanaDatasource`, `ServiceMonitor`, and the `Grafana` instance labels
- All matchLabels and labels move together so the operator continues to discover dashboards/datasources without interruption
- Source of change: aligns with upstream onedr0p/home-ops convention

## Test plan
- [ ] After merge, confirm dashboards still appear in Grafana
- [ ] Verify no stale matchLabels reference the old key