### PR TITLE
fix(cloudflare-dns): use %{record_type} txtPrefix

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
       - crd
       - gateway-httproute
     txtOwnerId: default
-    txtPrefix: k8s.
+    txtPrefix: k8s.%{record_type}-
     domainFilters:
       - blkh.dev
     serviceMonitor:


### PR DESCRIPTION
## Summary
- Change `txtPrefix: k8s.` to `txtPrefix: k8s.%{record_type}-` so external-dns can own multiple record types (A, CNAME, AAAA) for the same hostname without TXT collisions

## ⚠️ Runtime impact
On first reconcile, external-dns will not recognize existing TXT ownership records (they have the old prefix) and will re-register them under the new prefix. With `policy: sync` records are recreated, but expect a brief reconciliation window. **Apply off-hours.**

## Test plan
- [ ] Watch external-dns logs during first reconcile
- [ ] Verify all expected records still resolve afterward