### PR TITLE
fix(unifi-dns): switch webhook image and use %{record_type} txtPrefix

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -15,8 +15,8 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.4@sha256:ffb5dab38e52f8eaa714dd9e9e43575cd2cac7f68191b2d077940f13e397bed7
         env:
           - name: UNIFI_HOST
             value: https://unifi.internal
@@ -43,7 +43,7 @@ spec:
       - gateway-httproute
       - service
     txtOwnerId: main
-    txtPrefix: k8s.main.
+    txtPrefix: k8s.main.%{record_type}-
     domainFilters:
       - blkh.dev
     serviceMonitor:


### PR DESCRIPTION
## Summary
- Migrate UniFi external-dns webhook from `ghcr.io/kashalls/external-dns-unifi-webhook` to `ghcr.io/home-operations/external-dns-unifi-webhook` (rebranded fork by the same maintainers)
- Add `%{record_type}-` to `txtPrefix` so external-dns can own multiple record types per hostname

## ⚠️ Runtime impact
On first reconcile, external-dns will not recognize existing TXT ownership records (they have the old prefix) and will re-register them under the new prefix. **Apply off-hours.**

## Test plan
- [ ] Webhook pod starts and reports healthy
- [ ] All UniFi DNS records still resolve after reconcile