### PR TITLE
fix(silence-operator): use FQDN for alertmanager address

### DIFF
--- a/kubernetes/apps/o11y/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/silence-operator/app/helmrelease.yaml
@@ -10,6 +10,6 @@ spec:
     name: silence-operator
   interval: 1h
   values:
-    alertmanagerAddress: http://kube-prometheus-stack-alertmanager:9093
+    alertmanagerAddress: http://alertmanager-operated.o11y.svc.cluster.local:9093
     networkPolicy:
       enabled: false


### PR DESCRIPTION
## Summary
- Switch silence-operator's `alertmanagerAddress` from the short-name service to its in-cluster FQDN `http://alertmanager-operated.o11y.svc.cluster.local:9093`
- Avoids ambiguity from search-domain order and works correctly across namespaces

## Test plan
- [ ] silence-operator pod restarts cleanly
- [ ] Silences continue to be created/managed