### PR TITLE
feat(onepassword-connect): auto-reload on credentials change

### DIFF
--- a/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   interval: 1h
   values:
     connect:
+      annotations:
+        reloader.stakater.com/auto: "true"
       api:
         httpPort: 80
         imageRepository: ghcr.io/1password/connect-api


### PR DESCRIPTION
## Summary
- Add `reloader.stakater.com/auto: \"true\"` annotation to onepassword-connect so pods automatically restart when the credentials secret rotates

## Test plan
- [ ] Rotate the credentials secret and confirm pods recycle automatically