### PR TITLE
chore(alerts): silence transient tcp unreachable reconcile errors

### DIFF
--- a/kubernetes/components/alerts/alertmanager/alert.yaml
+++ b/kubernetes/components/alerts/alertmanager/alert.yaml
@@ -24,5 +24,6 @@ spec:
   exclusionList:
     - error.*lookup.*github
     - dial.*tcp.*timeout
+    - dial.*tcp.*unreachable
     - waiting.*socket
   suspend: false


### PR DESCRIPTION
## Summary
- Add `dial.*tcp.*unreachable` to the alertmanager `Alert.exclusionList`
- Suppresses noisy transient TCP errors that resolve on the next Flux reconcile, similar to the existing `dial.*tcp.*timeout` exclusion

## Test plan
- [ ] Confirm Flux reconcile alerts continue to fire for non-transient errors