### PR TITLE
feat(flux): enable DefaultToRetryOnFailure feature gate

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -106,11 +106,11 @@ spec:
             target:
               kind: Deployment
               name: helm-controller
-          - # Disable chart digest tracking
+          - # Default to retry on failure and disable chart digest tracking
             patch: |-
               - op: add
                 path: /spec/template/spec/containers/0/args/-
-                value: --feature-gates=DisableChartDigestTracking=true
+                value: --feature-gates=DefaultToRetryOnFailure=true,DisableChartDigestTracking=true
             target:
               kind: Deployment
               name: helm-controller

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -33,8 +33,6 @@ spec:
                 spec:
                   install:
                     crds: CreateReplace
-                    strategy:
-                      name: RetryOnFailure
                   rollback:
                     cleanupOnFail: true
                   upgrade:


### PR DESCRIPTION
## Summary
- Add `DefaultToRetryOnFailure=true` to the helm-controller feature gates
- Drop the now-redundant `install.strategy.name: RetryOnFailure` patch from \`kubernetes/flux/cluster/ks.yaml\`
- All HelmReleases now retry install on failure by default — no per-HR patch needed

## Test plan
- [ ] helm-controller pod restarts cleanly
- [ ] Force a transient failure on a HelmRelease and confirm it retries