### PR TITLE
fix(tuppr): tighten ReplicationSource Synchronizing health check expr

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -12,4 +12,4 @@ spec:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        !has(status.conditions) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -14,4 +14,4 @@ spec:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        !has(status.conditions) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")


### PR DESCRIPTION
## Summary
- Remove the `!has(status.conditions) ||` fallback from the Synchronizing health check expr in both KubernetesUpgrade and TalosUpgrade
- Flux now always reports the Synchronizing condition, so the fallback would only ever mask real volsync churn

## Test plan
- [ ] Next tuppr-triggered upgrade gates correctly on volsync state