### PR TITLE
feat(cloudflare-tunnel): tune keepalives and depend on cloudflare-dns

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -24,8 +24,6 @@ spec:
             env:
               NO_AUTOUPDATE: true
               TUNNEL_METRICS: 0.0.0.0:8080
-              TUNNEL_POST_QUANTUM: false # enable when using quic
-              TUNNEL_TRANSPORT_PROTOCOL: http2
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
@@ -76,7 +74,9 @@ spec:
               - hostname: "*.blkh.dev"
                 originRequest:
                   http2Origin: true
+                  keepAliveTimeout: 3600s
                   originServerName: external.blkh.dev
+                  tcpKeepAlive: 7200s
                 service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
               - service: http_status:404
     persistence:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: cloudflare-tunnel
 spec:
+  dependsOn:
+    - name: cloudflare-dns
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:


### PR DESCRIPTION
## Summary
- Add `keepAliveTimeout: 3600s` and `tcpKeepAlive: 7200s` to the per-ingress `originRequest` so long-lived WebSocket / streaming connections aren't cut early
- Remove `TUNNEL_POST_QUANTUM` and `TUNNEL_TRANSPORT_PROTOCOL` env vars (now defaults)
- Add `dependsOn: cloudflare-dns` to the Kustomization

## Test plan
- [ ] Tunnel pods restart cleanly with new config
- [ ] WebSocket connections (e.g., long polling apps) stay open past previous cut-off