### PR TITLE
fix(intel-gpu-resource-driver): run kubelet plugin privileged

### DIFF
--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/app/helmrelease.yaml
@@ -14,5 +14,6 @@ spec:
       staticPath: /run/cdi
       dynamicPath: /run/cdi
     kubeletPlugin:
+      privileged: true
       healthMonitoring:
         enabled: false


### PR DESCRIPTION
## Summary
- Set `kubeletPlugin.privileged: true` so the DaemonSet can mount the CDI socket and access GPU devices (required by newer chart versions)

## Test plan
- [ ] Plugin pods start without permission errors
- [ ] Workloads requesting GPU resources continue to schedule