### PR TITLE
refactor(flux-operator): move HTTPRoute into chart values

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -22,3 +22,10 @@ spec:
               - flux-admin
       networkPolicy:
         create: false
+      httpRoute:
+        enabled: true
+        hostnames:
+          - flux-operator.blkh.dev
+        parentRefs:
+          - name: envoy-internal
+            namespace: network

--- a/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
@@ -5,5 +5,4 @@ kind: Kustomization
 resources:
   - ./clusterrolebinding.yaml
   - ./helmrelease.yaml
-  - ./httproute.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary
- Use the chart's built-in `httpRoute` block instead of a standalone HTTPRoute manifest
- Delete `kubernetes/apps/flux-system/flux-operator/app/httproute.yaml` and remove it from the kustomization

## Test plan
- [ ] HelmRelease reconciles cleanly
- [ ] flux-operator.blkh.dev still serves the UI