### PR TITLE
feat(tuppr): use chart-bundled PrometheusRule and dashboards

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -14,3 +14,11 @@ spec:
     monitoring:
       serviceMonitor:
         enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -5,4 +5,3 @@ kind: Kustomization
 resources:
   - ./kubernetesupgrade.yaml
   - ./talosupgrade.yaml
-  - ./prometheusrule.yaml


### PR DESCRIPTION
## Summary
- Enable \`monitoring.prometheusRule\` and \`monitoring.dashboards\` in the tuppr HelmRelease
- Delete the custom \`upgrades/prometheusrule.yaml\` (verified identical to what the chart now bundles)
- Grafana dashboards are auto-discovered via the new \`dashboards: grafana\` label

## Test plan
- [ ] PrometheusRule resource created by the chart matches the previous alert set
- [ ] tuppr Grafana dashboard appears