### PR TITLE
chore(seerr): switch image to ghcr.io/seerr-team/seerr

### DIFF
--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -17,8 +17,8 @@ spec:
         containers:
           app:
             image:
-              repository: docker.io/seerr/seerr
-              tag: v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8 
+              repository: ghcr.io/seerr-team/seerr
+              tag: v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8
             env:
               TZ: America/Santiago
               LOG_LEVEL: "info"


### PR DESCRIPTION
## Summary
- Switch seerr image from \`docker.io/seerr/seerr\` to \`ghcr.io/seerr-team/seerr\`
- Same SHA, so no behavioral change — Renovate will now track updates from the official registry

## Test plan
- [ ] Pod restarts pulling from new registry
- [ ] App is reachable and usable