### PR TITLE
feat(qui): expose Prometheus metrics and add Grafana dashboard

### DIFF
--- a/kubernetes/apps/media/qui/app/grafanadashboard.yaml
+++ b/kubernetes/apps/media/qui/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: qui
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/25156/revisions/1/download

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
             env:
               QUI__HOST: 0.0.0.0
               QUI__PORT: &port 80
+              QUI__METRICS_ENABLED: true
+              QUI__METRICS_HOST: 0.0.0.0
+              QUI__METRICS_PORT: &metricsPort 8080
               TZ: America/Santiago
             envFrom:
               - secretRef:
@@ -60,6 +63,12 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
     route:
       app:
         hostnames:

--- a/kubernetes/apps/media/qui/app/kustomization.yaml
+++ b/kubernetes/apps/media/qui/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary
- Turn on \`QUI__METRICS_ENABLED\` and bind the metrics endpoint to port 8080
- Add the \`metrics\` service port and a ServiceMonitor endpoint so Prometheus scrapes qui
- Add the qui Grafana dashboard (grafana.com/dashboards/25156)

## Test plan
- [ ] qui pod restarts cleanly with the new env
- [ ] Prometheus scrape target appears healthy
- [ ] Dashboard renders with data after first scrape interval