### PR TITLE
feat(konflate): deploy konflate for rendered Flux PR diffs

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-webhook-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-webhook-token-secret
+    template:
+      data:
+        KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: konflate
+    - extract:
+        key: github-bot

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  interval: 1h
+  values:
+    config:
+      repo: github://blackjid/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://{{ .Release.Name }}.blkh.dev
+      mcp: true
+    secret:
+      existingSecret: konflate-webhook-token-secret
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+      hostnames:
+        - "{{ .Release.Name }}.blkh.dev"
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.26
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: konflate
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: flux-system
+  wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./namespace.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml
+  - ./konflate/ks.yaml


### PR DESCRIPTION
## Summary

- Deploys [konflate](https://github.com/home-operations/konflate) (chart `0.2.26`) under `flux-system`, exposed at `https://konflate.blkh.dev` via `envoy-external`.
- Write-back enabled: posts commit status checks and PR comment summaries on each rendered PR. Read-only MCP endpoint at `/mcp` is on.
- Secrets pulled from 1Password via `onepassword-connect`:
  - `konflate` → `KONFLATE_WEBHOOK_SECRET`
  - `github-bot` → `KONFLATE_APP_CLIENT_ID`, `KONFLATE_APP_PRIVATE_KEY`

Mirrors [onedr0p/home-ops#10987](https://github.com/onedr0p/home-ops/pull/10987), adapted to this repo (domain, repo URI).

## Test plan

- [ ] Add `konflate` item to 1Password with `KONFLATE_WEBHOOK_SECRET`
- [ ] Add `github-bot` item to 1Password with `GITHUB_BOT_APP_CLIENT_ID` and `GITHUB_BOT_APP_PRIVATE_KEY` (from a GitHub App with PR read + commit status write installed on `blackjid/home-ops`)
- [ ] Merge, confirm Flux reconciles the `konflate` Kustomization
- [ ] Verify the `konflate-webhook-token-secret` Secret materializes
- [ ] Browse `https://konflate.blkh.dev` — open PRs list and rendered diffs appear
- [ ] Configure GitHub webhook at `https://konflate.blkh.dev/hooks` using the webhook secret; push a test PR and confirm status check + comment posted