### PR TITLE
refactor(github-status): source GitHub App creds from `github-bot` 1P item

### DIFF
--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -12,9 +12,9 @@ spec:
     name: github-status-app
     template:
       data:
-        githubAppID: '{{ .GITHUB_APP_ID }}'
-        githubAppInstallationID: '{{ .GITHUB_APP_INSTALLATION_ID }}'
-        githubAppPrivateKey: '{{ .GITHUB_APP_PRIVATE_KEY }}'
+        githubAppID: '{{ .GITHUB_BOT_APP_ID }}'
+        githubAppInstallationID: '{{ .GITHUB_BOT_APP_INSTALLATION_ID }}'
+        githubAppPrivateKey: '{{ .GITHUB_BOT_APP_PRIVATE_KEY }}'
   dataFrom:
     - extract:
-        key: github-app
+        key: github-bot


### PR DESCRIPTION
## Summary

- Switches the `github-status` Flux Provider's `ExternalSecret` to extract from the new `github-bot` 1Password item used by konflate, instead of the legacy `github-app` item.
- Keys renamed: `GITHUB_APP_ID` → `GITHUB_BOT_APP_ID`, `GITHUB_APP_INSTALLATION_ID` → `GITHUB_BOT_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` → `GITHUB_BOT_APP_PRIVATE_KEY`.

The Flux notification-controller `Provider` (type: `github`) still requires the numeric **App ID** + **Installation ID** + **Private Key** — [upstream](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1/gitrepositories.md) has no Client ID support yet, so those three fields remain on the rendered Secret. Konflate's Client ID lives alongside them in the same `github-bot` 1P item but is consumed only by konflate.

## Test plan

- [ ] Ensure the `github-bot` 1P item contains `GITHUB_BOT_APP_ID`, `GITHUB_BOT_APP_INSTALLATION_ID`, and `GITHUB_BOT_APP_PRIVATE_KEY` (in addition to the `GITHUB_BOT_APP_CLIENT_ID` already used by konflate)
- [ ] Verify the underlying GitHub App still has commit-status write + the install on `blackjid/home-ops`
- [ ] Merge, confirm Flux reconciles and the `github-status-app` Secret materializes with the renamed source keys
- [ ] Push a commit to a PR and confirm a commit status is posted by the `github-status` Provider
- [ ] Once confirmed, retire the legacy `github-app` 1P item