### PR TITLE
refactor(github-status): use FLUX_GITHUB_TOKEN from flux 1P item

### DIFF
--- a/kubernetes/components/alerts/github-status/alert.yaml
+++ b/kubernetes/components/alerts/github-status/alert.yaml
@@ -10,7 +10,3 @@ spec:
   eventSources:
     - kind: Kustomization
       name: "*"
-  eventMetadata:
-    env: "production"
-    cluster: "my-cluster"
-    target_url: "https://github.com/blackjid/home-ops"

--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -3,18 +3,16 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: github-status-app
+  name: github-status-token
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: github-status-app
+    name: github-status-token-secret
     template:
       data:
-        githubAppID: '{{ .GITHUB_APP_ID }}'
-        githubAppInstallationID: '{{ .GITHUB_APP_INSTALLATION_ID }}'
-        githubAppPrivateKey: '{{ .GITHUB_APP_PRIVATE_KEY }}'
+        token: "{{ .FLUX_GITHUB_TOKEN }}"
   dataFrom:
     - extract:
-        key: github-app
+        key: flux

--- a/kubernetes/components/alerts/github-status/provider.yaml
+++ b/kubernetes/components/alerts/github-status/provider.yaml
@@ -8,4 +8,4 @@ spec:
   type: github
   address: https://github.com/blackjid/home-ops
   secretRef:
-    name: github-status-app
+    name: github-status-token-secret


### PR DESCRIPTION
## Summary
- Switches the `github-status` Flux Provider from GitHub App auth to a simple token (`FLUX_GITHUB_TOKEN`) sourced from the existing `flux` 1Password item, matching upstream onedr0p layout.
- Renames the ExternalSecret/target Secret to `github-status-token` / `github-status-token-secret`.
- Drops the placeholder `eventMetadata` block from the `github-status` Alert.

## Notes
- Requires `FLUX_GITHUB_TOKEN` to be present in the `flux` 1Password item.
- After this lands, the old `github-status-app` ExternalSecret and downstream Secret should be pruned by Flux/ESO automatically; verify with `kubectl -n flux-system get externalsecret,secret | grep github-status` if curious.
- The unused `GITHUB_BOT_APP_ID` / `GITHUB_BOT_APP_INSTALLATION_ID` fields in the `github-bot` 1P item can be cleaned up. `GITHUB_BOT_APP_CLIENT_ID` / `GITHUB_BOT_APP_PRIVATE_KEY` are still in use by konflate and must be kept.

## Test plan
- [ ] Flux reconciles the `alerts` component without errors
- [ ] `github-status-token-secret` is populated in `flux-system`
- [ ] Commit statuses still appear on PRs against this repo