### PR TITLE
refactor(renovate): source bot credentials from 1Password

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,7 +10,7 @@ on:
       - .renovaterc.json5
       - .renovate/**.json5
   schedule:
-    - cron: 0 * * * *
+    - cron: 20 * * * *
   workflow_dispatch:
     inputs:
       dryRun:
@@ -45,12 +45,27 @@ jobs:
     permissions:
       packages: read
     steps:
+      - name: Load Secrets
+        id: load-secrets
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1 # zizmor: ignore[unpinned-tools]
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GITHUB_BOT_APP_CLIENT_ID: op://kubernetes/github-bot/GITHUB_BOT_APP_CLIENT_ID
+          GITHUB_BOT_APP_PRIVATE_KEY: op://kubernetes/github-bot/GITHUB_BOT_APP_PRIVATE_KEY
+
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          client-id: ${{ steps.load-secrets.outputs.GITHUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ steps.load-secrets.outputs.GITHUB_BOT_APP_PRIVATE_KEY }}
+          permission-checks: write
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-statuses: write
+          permission-vulnerability-alerts: read
+          permission-workflows: write
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary
- Replace repo secrets `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` with `1password/load-secrets-action`, pulling `GITHUB_BOT_APP_CLIENT_ID` and `GITHUB_BOT_APP_PRIVATE_KEY` from the existing `github-bot` 1P item — same pattern as the github-status refactor (#5920).
- Switch `create-github-app-token` to the `client-id` form and narrow the issued token to just the permissions Renovate uses: checks, contents, issues, PRs, statuses, vulnerability-alerts, workflows.
- Offset the schedule to `20 * * * *` to avoid the top-of-hour Actions rush.

## Test plan
- [ ] Confirm `OP_SERVICE_ACCOUNT_TOKEN` is set as a repo secret and the `github-bot` 1P item exposes `GITHUB_BOT_APP_CLIENT_ID` + `GITHUB_BOT_APP_PRIVATE_KEY`.
- [ ] Run the workflow via `workflow_dispatch` with `dryRun: true` and confirm the Load Secrets + Generate Token steps succeed and Renovate enumerates updates.
- [ ] After merge, watch the next scheduled run (`20 * * * *`) and confirm a PR or issue update goes through with the narrowed token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)