### PR TITLE
fix(plex): use /identity for gatus health check

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |-
-            conditions: ["[STATUS] == 401"]
+            path: /identity
         hostnames:
           - "{{ .Release.Name }}.blkh.dev"
         parentRefs:


### PR DESCRIPTION
## Summary
- Plex's root path now returns 404 instead of 401, breaking the existing `[STATUS] == 401` Gatus condition.
- Switch to `path: /identity` (the public Plex identity endpoint that returns 200), matching upstream onedr0p config.

## Test plan
- [ ] Flux reconciles HelmRelease without diff errors
- [ ] Gatus shows plex endpoint healthy (200 on `/identity`)