### PR TITLE
feat(o11y): align kube-prometheus-stack with onedr0p config

### DIFF
--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
@@ -9,6 +9,10 @@ spec:
     kind: OCIRepository
     name: kube-prometheus-stack
   interval: 1h
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-metrics-configmap
+      valuesKey: flux-metrics.yaml
   values:
     cleanPrometheusOperatorObjectNames: true
     alertmanager:
@@ -48,22 +52,12 @@ spec:
               namespace: network
       prometheusSpec:
         externalUrl: https://prometheus.blkh.dev
-        version: v2.55.1 # override 'unsupported Prometheus version' error for prompp
-        image:
-          registry: mirror.gcr.io
-          repository: prompp/prompp
-          tag: 0.8.0
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 64535
-          runAsGroup: 64535
-          fsGroup: 64535
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         ruleSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
-        retention: 14d
+        retention: 30d
         retentionSize: 50GB
         resources:
           requests:
@@ -76,7 +70,7 @@ spec:
               storageClassName: longhorn
               resources:
                 requests:
-                  storage: 55Gi
+                  storage: 50Gi
     prometheus-node-exporter:
       fullnameOverride: node-exporter
     kube-state-metrics:

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
@@ -9,3 +9,11 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./scrapeconfig.yaml
+configMapGenerator:
+  - name: flux-metrics-configmap
+    files:
+      - flux-metrics.yaml=./resources/flux-metrics.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/resources/flux-metrics.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/resources/flux-metrics.yaml
@@ -1,0 +1,364 @@
+---
+kube-state-metrics:
+  rbac:
+    extraRules:
+      - apiGroups:
+          - source.toolkit.fluxcd.io
+          - kustomize.toolkit.fluxcd.io
+          - helm.toolkit.fluxcd.io
+          - notification.toolkit.fluxcd.io
+        resources:
+          - gitrepositories
+          - buckets
+          - helmrepositories
+          - helmcharts
+          - ocirepositories
+          - kustomizations
+          - helmreleases
+          - alerts
+          - providers
+          - receivers
+        verbs:
+          - list
+          - watch
+  customResourceState:
+    enabled: true
+    config:
+      spec:
+        resources:
+          - groupVersionKind:
+              group: kustomize.toolkit.fluxcd.io
+              version: v1
+              kind: Kustomization
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Kustomization resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - lastAppliedRevision
+                  source_name:
+                    - spec
+                    - sourceRef
+                    - name
+          - groupVersionKind:
+              group: helm.toolkit.fluxcd.io
+              version: v2
+              kind: HelmRelease
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmRelease resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - history
+                    - "0"
+                    - chartVersion
+                  chart_name:
+                    - status
+                    - history
+                    - "0"
+                    - chartName
+                  chart_app_version:
+                    - status
+                    - history
+                    - "0"
+                    - appVersion
+                  chart_ref_name:
+                    - spec
+                    - chartRef
+                    - name
+                  chart_source_name:
+                    - spec
+                    - chart
+                    - spec
+                    - sourceRef
+                    - name
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: GitRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux GitRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: Bucket
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Bucket resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  endpoint:
+                    - spec
+                    - endpoint
+                  bucket_name:
+                    - spec
+                    - bucketName
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmChart
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmChart resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  chart_name:
+                    - spec
+                    - chart
+                  chart_version:
+                    - spec
+                    - version
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: OCIRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux OCIRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Alert
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Alert resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  suspended:
+                    - spec
+                    - suspend
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Provider
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Provider resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  suspended:
+                    - spec
+                    - suspend
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1
+              kind: Receiver
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Receiver resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  webhook_path:
+                    - status
+                    - webhookPath


### PR DESCRIPTION
## Summary

Pull our `kube-prometheus-stack` HelmRelease closer to onedr0p's reference config, while keeping cluster-specific bits (Longhorn storage, `blkh.dev` hostnames, no ZFS rules):

- Drop the `prompp/prompp` Prometheus override (version pin `v2.55.1`, custom image, and custom `securityContext`) — fall back to the chart default.
- Bump retention `14d → 30d` and shrink storage `55Gi → 50Gi`.
- Add a `flux-metrics-configmap` (copied from onedr0p) and wire it via `valuesFrom`. This grants kube-state-metrics extra RBAC and `customResourceState` rules so it emits `gotk_*` metrics for Flux CRs (Kustomization, HelmRelease, GitRepository, OCIRepository, Bucket, HelmRepository, HelmChart, Alert, Provider, Receiver).

## Test plan

- [ ] `kustomize build kubernetes/apps/o11y/kube-prometheus-stack/app` renders cleanly (verified locally).
- [ ] After merge, confirm the Prometheus pod rolls without the prompp image and stays Ready — and that no in-use feature relied on PromPP extensions.
- [ ] Confirm Prometheus PVC size shows `50Gi` (Longhorn will resize down only via recreate — may need manual handling depending on what's already provisioned).
- [ ] Confirm retention extends out to 30d once the new pod is steady.
- [ ] Query `gotk_kustomization_resource_info` / `gotk_helmrelease_resource_info` in Prometheus to confirm KSM is now scraping Flux CRs.