### PR TITLE
feat(tuppr): wait for Longhorn volumes to be healthy between nodes

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -13,3 +13,9 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      timeout: 2h
+      expr: |-
+        status.state != "attached" || status.robustness == "healthy"

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -15,3 +15,9 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      timeout: 2h
+      expr: |-
+        status.state != "attached" || status.robustness == "healthy"


### PR DESCRIPTION
## Summary

- Adds a Longhorn `Volume` health check to the `TalosUpgrade` so the next node's upgrade blocks until every attached volume reports `robustness: healthy` (3/3 replicas running).
- Pairs with the existing `nodeDrainPolicy: allow-if-replica-is-stopped` + `replicaReplenishmentWaitInterval: 3600s` Longhorn config: drain is allowed when only this node holds a non-last replica, but tuppr now waits for the in-place rebuild to finish before draining the *next* node.
- Prevents the failure mode where two consecutive node upgrades leave only one healthy replica per volume — the third node's drain would then succeed for detached volumes but the volume would have no quorum to come back from if anything went wrong.

## CEL expression

```
status.state != "attached" || status.robustness == "healthy"
```

For every Longhorn Volume: if detached, skip; if attached, must be `healthy`. Detached 1-replica volsync targets (`robustness: unknown`) don't block.

`timeout: 2h` is set per check to accommodate full rebuilds on larger volumes (Longhorn throttles to 2 concurrent rebuilds).

## Test plan

- [ ] Flux reconciles the updated `TalosUpgrade` cleanly
- [ ] Trigger / wait for next Talos upgrade and observe tuppr waiting between nodes until all volumes are `Healthy` (Longhorn UI)
- [ ] Confirm detached volumes do not block the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)