### PR TITLE
feat(kopiur): deploy kopiur operator and adopt existing kopia repo

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  interval: 1h
+  values:
+    # Filesystem/NFS backend: the controller needs the repo mounted in-process
+    # to connect/list/discover snapshots, the same NFS export volsync's kopia
+    # mover already writes to.
+    extraVolumes:
+      - name: repo
+        nfs:
+          server: black-station.internal
+          path: /volume1/VolsyncKopia
+    extraVolumeMounts:
+      - name: repo
+        mountPath: /repo
+    features:
+      credentialProjection:
+        enabled: true
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.8.1
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kopiur
+      namespace: kopiur-system
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: nas
+spec:
+  allowedNamespaces:
+    all: true
+  backend:
+    filesystem:
+      path: /repo
+      volume:
+        nfs:
+          server: black-station.internal
+          path: /volume1/VolsyncKopia
+  create:
+    # This repo already exists and is written to by volsync's kopia mover.
+    # Adopt it in place, never re-initialize it.
+    enabled: false
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  maintenance:
+    # volsync's KopiaMaintenance CronJob still owns compaction on this repo.
+    # Flip this on only after that's decommissioned, to avoid two maintenance
+    # schedulers racing on the same repo.
+    enabled: false

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrepository.yaml

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+
+components:
+  - ../../components/alerts
+  - ../../components/kopiur/secret
+
+resources:
+  - ./namespace.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/kopiur/secret/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secret/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-repository
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-repository-secret
+    template:
+      data:
+        # Filesystem/NFS backend needs only the repository encryption password.
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/components/kopiur/secret/kustomization.yaml
+++ b/kubernetes/components/kopiur/secret/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml


### PR DESCRIPTION
## Summary
First PR of the VolSync -> Kopiur migration (part 1/3 planned: **dependencies** -> components -> single-workload test).

- Deploys the [kopiur](https://kopiur.home-operations.com/) operator (chart `0.8.1`) into a new `kopiur-system` namespace, following this repo's `ks.yaml`/component conventions.
- Connects a `ClusterRepository` (`nas`) to the **same** NFS-backed kopia repository volsync's kopia mover (`perfectra1n/volsync` fork) already writes to (`black-station.internal:/volume1/VolsyncKopia`).
- `create.enabled: false` on the `ClusterRepository` — this **adopts** the existing repo in place rather than initializing a new one, so no data is re-uploaded and existing volsync snapshots stay intact.
- `maintenance.enabled: false` for now — volsync's `KopiaMaintenance` CronJob still owns compaction on this repo. We'll flip this on once volsync is decommissioned, to avoid two maintenance schedulers racing on the same repo.
- No application is wired up to kopiur yet. VolSync continues to run completely unaffected by this PR.

Field names for `ClusterRepository`/`HelmRelease` values were verified against the actual CRD schemas and chart `values.yaml` shipped in `oci://ghcr.io/home-operations/charts/kopiur:0.8.1` (pulled and inspected locally), not just docs, since the CRD schema has changed across kopiur releases.

Requires a 1Password item named `kopiur` (same vault as `volsync-template`) with a `KOPIA_PASSWORD` field set to the **same value** as `volsync-template`'s `KOPIA_PASSWORD` — needed so kopiur can decrypt the existing repo.

## Test plan
- [ ] 1Password item `kopiur` created with matching `KOPIA_PASSWORD`
- [ ] `kustomize build` passes for all new directories (done locally)
- [ ] After merge: `kopiur-system` HelmRelease and both Kustomizations (`kopiur`, `kopiur-repository`) go Ready
- [ ] `ClusterRepository/nas` reaches `Ready`/connected status without attempting to re-create the repo
- [ ] VolSync's `ReplicationSource`/`ReplicationDestination` objects and schedules are unaffected

## Next PRs
1. Reusable `components/kopiur/backup` kustomize component (SnapshotPolicy/SnapshotSchedule/PVC/Restore) for Longhorn, parameterized like the existing `components/volsync`.
2. Cut over a single low-risk workload (`actual`) using `kubectl kopiur migrate volsync`, which preserves the existing per-app kopia snapshot identity/history for this repo type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)