### PR TITLE
feat(actual): back up with kopiur alongside volsync

### DIFF
--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -6,16 +6,45 @@ metadata:
   name: actual
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
+  patches:
+    # Pin the kopiur snapshot identity to the one the perfectra1n/volsync
+    # fork already wrote to this repo (see `kubectl kopiur migrate volsync`
+    # output), so kopiur's snapshots continue the same history instead of
+    # starting a new lineage. Test-only: kopiur and volsync both back up
+    # this PVC in parallel for now, nothing else changes yet.
+    #
+    # metadata.name/sources[].pvc.name must stay "${APP}" (not "actual"):
+    # postBuild.substitute runs as a text pass AFTER kustomize patches, so
+    # at patch time the SnapshotPolicy's name is still the literal token.
+    - patch: |-
+        apiVersion: kopiur.home-operations.com/v1alpha1
+        kind: SnapshotPolicy
+        metadata:
+          name: ${APP}
+        spec:
+          identity:
+            hostname: default
+            username: actual
+          sources:
+            - pvc:
+                name: ${APP}
+              sourcePathOverride: /data
+      target:
+        kind: SnapshotPolicy
   path: ./kubernetes/apps/default/actual/app
   postBuild:
     substitute:
       APP: actual
+      KOPIUR_CAPACITY: 2Gi
       VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
Third PR of the VolSync -> Kopiur migration (3/3: dependencies -> components -> **single-workload test**). Stacked on #6146 and #6147.

- Adds `components/kopiur/backup` to `actual`'s `ks.yaml`, running fully **in parallel** with its existing `components/volsync` — neither touches the other's resources (no PVC/Restore involved yet), so this is trivially reversible by dropping the component again.
- Pins `SnapshotPolicy.spec.identity` to `{hostname: default, username: actual}` (`actual@default:/data`) via a `patches:` entry, so kopiur continues the exact same kopia snapshot history the `perfectra1n/volsync` fork already wrote, instead of starting a new lineage.
- The identity was confirmed two ways against the live cluster (read-only, no changes made):
  - `kubectl get replicationsource actual -n default -o yaml` — mover logs show `Setting policy for actual@default:/data`.
  - `kubectl kopiur migrate volsync -n default --name actual --repository nas --repository-kind cluster-repository --include-destinations -o yaml -v` — the real migration tool independently derives the same `actual@default:/data` identity and confirms "REPOSITORY ADOPTED IN PLACE — all existing snapshots are preserved".
- Adds `dependsOn: kopiur-repository` (from #6146) alongside the existing `longhorn` dependency.

One implementation gotcha worth flagging for reviewers: the patch's `target`/`metadata.name` had to stay the literal `${APP}` token, not `actual` — Flux's `postBuild.substitute` runs as a text pass *after* kustomize patches are applied, so at patch-matching time the resource's name is still unsubstituted. Verified by rendering the full kustomize build + a simulated substitution pass locally before pushing.

## Why not a full cutover yet
A PVC's `dataSourceRef` is immutable once bound. Swapping `components/volsync`'s PVC (dataSourceRef -> `ReplicationDestination`) for `components/kopiur/restore`'s PVC (dataSourceRef -> `Restore`) on `actual`'s already-bound, already-populated PVC in the same reconcile would make Flux attempt (and fail) an illegal field update. onedr0p's own migration hit this and ran backup-only in parallel first too. That swap is a deliberate follow-up once this PR proves out, not bundled here.

## Test plan
- [ ] `kustomize build` (with components + patches + a simulated `postBuild.substitute` pass) renders a schema-valid `SnapshotPolicy`/`SnapshotSchedule` with the pinned identity (verified locally)
- [ ] After merge: `SnapshotPolicy/actual` and `SnapshotSchedule/actual` reconcile successfully in the `default` namespace
- [ ] A manual `kubectl kopiur snapshot now --policy actual -n default --wait` (or waiting for the schedule) produces a new snapshot
- [ ] `kubectl kopiur snapshots list -n default` (or `kopia snapshot list` for `actual@default`) shows the new kopiur snapshot continuing the same history as volsync's prior snapshots — no new/duplicate lineage
- [ ] volsync's `ReplicationSource actual` / `ReplicationDestination actual-dst` and their schedule are completely unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)