### PR TITLE
fix(actual): simplify to match onedr0p's kopiur structure exactly

### DIFF
--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -6,9 +6,12 @@ metadata:
   name: actual
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: longhorn
       namespace: longhorn-system
   interval: 1h
@@ -16,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: actual
+      KOPIUR_CAPACITY: 2Gi
       VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
Replaces the approach from #6148 after checking it against both the live cluster and onedr0p's own kopiur migration (the reference this whole effort is modeled on).

**What was wrong with #6148:** it added an `identity`/`sourcePathOverride` patch to `actual`'s `ks.yaml` meant to continue the exact kopia snapshot lineage the `perfectra1n/volsync` fork had written. It never actually took effect — `kubectl get snapshotpolicy actual -n default` showed no `spec.identity` at all, and `status.resolved.identity.sourcePath` was `/pvc/actual` instead of `/data`. Root cause: the root `cluster-apps` Kustomization (`kubernetes/flux/cluster/ks.yaml`) strategic-merge-patches `spec.patches` onto *every* child `kustomize.toolkit.fluxcd.io` Kustomization (to inject HelmRelease upgrade defaults). `kustomize` has no merge-key schema for that CRD's `spec.patches` list, so it's a whole-list **replace**, not a merge — it silently discarded the patch `actual`'s own `ks.yaml` had set. No snapshot had run yet when this was caught, so no wrong-identity snapshot was ever created.

**What changed after checking onedr0p's reference repo:** they have the *identical* root-level wildcard patch (this repo forked their structure). Correspondingly, **zero** app `ks.yaml` or `app/kustomization.yaml` files anywhere in their repo use `patches:` for kopiur — not for `atuin`, `plex`, or anyone. Their `components/kopiur/backup/snapshotpolicy.yaml` has no `identity` or `sourcePathOverride` field either. Their fork-based apps' kopiur cutover simply accepted a **fresh snapshot lineage** per app going forward; the old volsync-written snapshots stay in the shared repository as inert `discovered` history (visible via `kubectl get snapshots`) rather than being chained into the new series.

## This PR
Drops the identity patch entirely and reverts `app/kustomization.yaml`, so `actual`'s `ks.yaml` is shaped **exactly** like onedr0p's `atuin`/`plex`:
```yaml
spec:
  components:
    - ../../../../components/kopiur/backup
    - ../../../../components/volsync
    - ../../../../components/zeroscaler
  postBuild:
    substitute:
      APP: actual
      KOPIUR_CAPACITY: 2Gi
      VOLSYNC_CAPACITY: 2Gi
```
kopiur will start a new snapshot lineage for `actual`; its 15 existing volsync-kopia snapshots remain discoverable in the shared repo, just not continued as the same series. `dependsOn: kopiur-repository` is kept.

## Test plan
- [x] `kustomize build` (app + components, simulating Flux's resolution) renders a schema-valid `SnapshotPolicy`/`SnapshotSchedule` with no leftover identity fields (verified locally)
- [ ] After merge: `SnapshotPolicy/actual` and `SnapshotSchedule/actual` reconcile; `status.resolved.identity` shows kopiur's own auto-derived defaults
- [ ] Volsync's `ReplicationSource actual` continues unaffected in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)