### PR TITLE
fix(kopiur): distribute repo credentials with ESO instead of projection

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: default
 
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secret
 
 resources:
   - ./namespace.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -21,9 +21,6 @@ spec:
     extraVolumeMounts:
       - name: repo
         mountPath: /repo
-    features:
-      credentialProjection:
-        enabled: true
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -8,8 +8,6 @@ spec:
   compression:
     compressor: zstd-fastest
   copyMethod: Snapshot
-  credentialProjection:
-    enabled: true
   mover:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}

--- a/kubernetes/components/kopiur/restore/restore.yaml
+++ b/kubernetes/components/kopiur/restore/restore.yaml
@@ -5,8 +5,6 @@ kind: Restore
 metadata:
   name: ${APP}
 spec:
-  credentialProjection:
-    enabled: true
   policy:
     # Empty volume if no snapshot exists yet (deploy-or-restore), instead of
     # failing a brand-new app that has never been backed up.


### PR DESCRIPTION
## Summary
Fixes a real failure hit while testing #6151 live: a manually-triggered snapshot for `actual` went `Pending` with:

```
credential Secret `kopiur-repository-secret` lives in namespace `kopiur-system`
but the mover Job runs in `default`, and projecting it across namespaces is not
permitted: the ClusterRepository owner has not allowed credential projection.
```

The quick fix is `spec.credentialProjection.allowed: true` on `ClusterRepository/nas`. Instead, checked onedr0p's reference repo and found they hit this **exact same issue** and moved away from `credentialProjection` entirely (`refactor(kopiur): distribute repo credentials with ESO #11215`) — their chart's own docs call unscoped cross-namespace secret writes a security trade-off, so they now create the repository Secret directly in each consuming namespace via ESO instead of granting the operator that RBAC.

## Changes (matching onedr0p's current state exactly)
- `kubernetes/apps/default/kustomization.yaml`: added `components/kopiur/secret`, so the `default` namespace gets its own local `kopiur-repository-secret`, pulled from the same `kopiur` 1Password item — same pattern already used for `kopiur-system` itself.
- `components/kopiur/backup/snapshotpolicy.yaml` / `components/kopiur/restore/restore.yaml`: dropped `credentialProjection.enabled` — the mover Job now finds the Secret locally in its own namespace, no cross-namespace copy needed.
- `kopiur-system/kopiur/app/helmrelease.yaml`: dropped `features.credentialProjection.enabled` — the operator no longer needs that RBAC grant at all.
- `ClusterRepository/nas` is left untouched — no `credentialProjection.allowed` field, matching onedr0p's current `clusterrepository.yaml` verbatim.

As more apps adopt `components/kopiur/backup`, their namespace's own `kustomization.yaml` will need the same `components/kopiur/secret` addition (one-time per namespace, not per app) — same as onedr0p's `default`/media/etc. namespace kustomizations all doing this today.

## Test plan
- [x] `kustomize build kubernetes/apps/default` renders a `kopiur-repository` `ExternalSecret` targeting `kopiur-repository-secret` in the `default` namespace (verified locally)
- [x] `kustomize build` on `components/kopiur/backup` and `components/kopiur/restore` still render schema-valid `SnapshotPolicy`/`SnapshotSchedule`/`Restore` (verified locally)
- [ ] After merge: `kubectl get secret kopiur-repository-secret -n default` exists
- [ ] A manual `kopiur snapshot now --policy actual -n default --wait` (or the next scheduled run) succeeds instead of going `Pending` with `MissingCredentialsSecret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)