### PR TITLE
fix(kopiur): stage snapshot clones on longhorn-snapshot

### DIFF
--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -27,4 +27,13 @@ spec:
   sources:
     - pvc:
         name: ${APP}
+  staging:
+    # WaitForFirstConsumer (unlike the default "longhorn" class, which binds
+    # Immediate) delays placing the staged clone until the mover pod is
+    # scheduled, so the volume follows the pod instead of racing it — the
+    # same class volsync always used the staged copy for, and for the same
+    # reason. Without this, a scheduled snapshot for actual failed: the mover
+    # pod got pinned to one node while Longhorn placed the clone's replica on
+    # another, and the two could never agree (0/3 nodes schedulable).
+    storageClassName: ${KOPIUR_STAGING_STORAGECLASS:=longhorn-snapshot}
   volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=longhorn-snapclass}


### PR DESCRIPTION
## Summary
A scheduled snapshot for `actual` failed this morning:

```
the mover pod has been stuck (Unschedulable) for over 300s and cannot start:
0/3 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity,
2 node(s) didn't match Pod's node affinity/selector.
```

Confirmed via `kubectl logs -n kopiur-system --previous` that staging itself succeeded fine (VolumeSnapshot ready, staged PVC bound) and the mover Job was created normally — the failure was purely mover-pod scheduling, ~5 minutes later (`MoverPodWedged`, matching the default 300s `podStartupDeadlineSeconds`). A manual `kubectl kopiur snapshot now --policy actual -n default` right after succeeded cleanly, confirming this was a scheduling race, not a hard failure.

**Root cause:** `SnapshotPolicy.spec.staging.storageClassName` was never set, so it defaulted to copying the source PVC's own class (`longhorn`), which binds `Immediate` — the staged clone's PV gets placed *before* any pod is scheduled, independently of wherever kopiur ends up pinning the mover pod. If Longhorn's placement and kopiur's pod pin disagree, you get 0/3 schedulable nodes.

VolSync already solved this: it always staged its own copies on `longhorn-snapshot` (1 replica, `volumeBindingMode: WaitForFirstConsumer` — see `kubernetes/apps/longhorn-system/longhorn/storageclass/snapshot.yaml`), specifically because `WaitForFirstConsumer` delays volume placement until the consuming pod is scheduled, so the volume follows the pod instead of racing it.

## Change
`components/kopiur/backup/snapshotpolicy.yaml`: set `spec.staging.storageClassName: ${KOPIUR_STAGING_STORAGECLASS:=longhorn-snapshot}`, pointing kopiur's staging at the same class VolSync always used for the same reason. No onedr0p equivalent to mirror here — this is a Longhorn-specific fix; Ceph RBD (their backend) doesn't have this class of PV node-affinity behavior.

## Test plan
- [x] `kustomize build components/kopiur/backup` renders the new `staging.storageClassName` field (verified locally)
- [x] Rendered `SnapshotPolicy` validates against the kopiur 0.8.1 CRD schema (verified locally)
- [ ] After merge: the next scheduled snapshot for `actual` (and any manual retrigger) completes without a `MoverPodWedged` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)