### PR TITLE
fix(kopiur): put the mover cache on longhorn-cache, not hostpath

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -10,9 +10,6 @@ spec:
     name: kopiur
   interval: 1h
   values:
-    # Filesystem/NFS backend: the controller needs the repo mounted in-process
-    # to connect/list/discover snapshots, the same NFS export volsync's kopia
-    # mover already writes to.
     extraVolumes:
       - name: repo
         nfs:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -15,16 +15,13 @@ spec:
           server: black-station.internal
           path: /volume1/VolsyncKopia
   create:
-    # This repo already exists and is written to by volsync's kopia mover.
-    # Adopt it in place, never re-initialize it.
-    enabled: false
+    enabled: false # adopt volsync's existing repo, never re-initialize
   encryption:
     passwordSecretRef:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
   maintenance:
-    # volsync's KopiaMaintenance CronJob still owns compaction on this repo.
-    # Flip this on only after that's decommissioned, to avoid two maintenance
-    # schedulers racing on the same repo.
-    enabled: false
+    enabled: false # volsync's KopiaMaintenance still owns compaction
+  scheduleDefaults:
+    timezone: America/Santiago

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -12,7 +12,12 @@ spec:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       mode: Persistent
-      storageClassName: ${KOPIUR_CACHE_STORAGECLASS:=openebs-hostpath}
+      # Must be network-attachable, NOT node-local: kopiur pins the mover pod
+      # itself (sourceColocation), so a Persistent cache on openebs-hostpath
+      # welds to whichever node created it and deadlocks every run pinned
+      # elsewhere. longhorn-cache is 1 replica (cheap, disposable) but
+      # attachable from any node, so the cache follows the mover.
+      storageClassName: ${KOPIUR_CACHE_STORAGECLASS:=longhorn-cache}
     podSecurityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -12,12 +12,7 @@ spec:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       mode: Persistent
-      # Must be network-attachable, NOT node-local: kopiur pins the mover pod
-      # itself (sourceColocation), so a Persistent cache on openebs-hostpath
-      # welds to whichever node created it and deadlocks every run pinned
-      # elsewhere. longhorn-cache is 1 replica (cheap, disposable) but
-      # attachable from any node, so the cache follows the mover.
-      storageClassName: ${KOPIUR_CACHE_STORAGECLASS:=longhorn-cache}
+      storageClassName: longhorn-cache
     podSecurityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -8,8 +8,5 @@ spec:
   policyRef:
     name: ${APP}
   schedule:
-    # Jenkins-style H pins a deterministic per-app minute so schedules spread
-    # out instead of every app snapshotting at exactly 04:00:00.
-    cron: "H 4 * * *"
-    jitter: 2m
+    cron: H 4 * * *
     timezone: America/Santiago

--- a/kubernetes/components/kopiur/restore/restore.yaml
+++ b/kubernetes/components/kopiur/restore/restore.yaml
@@ -6,12 +6,10 @@ metadata:
   name: ${APP}
 spec:
   policy:
-    # Empty volume if no snapshot exists yet (deploy-or-restore), instead of
-    # failing a brand-new app that has never been backed up.
     onMissingSnapshot: Continue
   source:
     fromPolicy:
       name: ${APP}
-      offset: 0 # 0 = latest snapshot
+      offset: 0
   target:
     populator: {}

--- a/kubernetes/components/kopiur/secret/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secret/externalsecret.yaml
@@ -12,7 +12,6 @@ spec:
     name: kopiur-repository-secret
     template:
       data:
-        # Filesystem/NFS backend needs only the repository encryption password.
         KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
## Summary
Fixes the failed scheduled snapshot for `actual`, and strips the verbose comments from the kopiur manifests so they match onedr0p's. Replaces #6153, whose diagnosis was wrong (details below).

```
the mover pod has been stuck (Unschedulable) for over 300s and cannot start:
0/3 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity,
2 node(s) didn't match Pod's node affinity/selector.
```

**Root cause:** `mover.cache` is `mode: Persistent` on `openebs-hostpath` — genuinely node-local storage. The `kopiur-cache-actual` PV is welded to `k8s-1` permanently. kopiur *also* pins the mover pod itself (`sourceColocation` defaults to `Auto`), so any run whose pod gets pinned to a different node can never satisfy the cache PV. That's exactly the error's arithmetic: **2 nodes** rejected by the pod pin, the **1 remaining** node rejected by the cache PV's affinity.

Worth noting VolSync has the *same* hostpath cache and never breaks — because it doesn't pin its mover pod, so the scheduler simply follows the existing cache PV. It's kopiur's pod pinning that turns a node-local persistent cache into a deadlock.

## The fix
Use `longhorn-cache`, which this repo already defines for precisely this job (*"we set this to 1 replica for less copies of the cache, which can be blown away safely"*).

Verified on the live cluster that a 1-replica Longhorn volume is **not** node-welded — I'd initially assumed otherwise and was wrong:

| Class | Replicas | PV node affinity (every live PV) |
|---|---|---|
| `longhorn-snapshot` | 1 | **all 3 nodes** |
| `openebs-hostpath` | n/a | **exactly 1 node** |

Longhorn v1 volumes are network-attached (iSCSI), so they're attachable from any node regardless of where the single replica lives. Only hostPath truly pins. So the cache keeps `mode: Persistent` (warm cache, fast incremental runs) and stays cheap at 1 replica, while being free to follow the mover pod anywhere.

This mirrors onedr0p, who moved their kopiur cache onto `miroir-slow` — replicated network storage — rather than leaving it on `openebs-hostpath`. `longhorn-cache` is our equivalent. (While they *were* on `openebs-hostpath`, they ran `mode: Ephemeral` for the same reason.)

## Second commit: align with onedr0p
Strips the long explanatory comment blocks from every kopiur manifest — theirs carry none; the rationale lives in PRs and commit history instead. Also:
- `mover.cache.storageClassName` hardcoded to `longhorn-cache`, mirroring how they hardcode `miroir-slow` rather than exposing a per-app variable
- dropped `SnapshotSchedule` `jitter` — Jenkins-style `H` already spreads runs
- moved the timezone default onto `ClusterRepository.scheduleDefaults`, as they do

The `SnapshotSchedule` deliberately keeps its own `timezone`: `scheduleDefaults` only feeds verification/replication/maintenance crons (per the CRD's own field docs), not `SnapshotSchedule`, and our cron pins a specific hour (`H 4 * * *`) rather than onedr0p's hourly `H * * * *` — so dropping it would silently move backups to 4am UTC (midnight Santiago).

## Why #6153 was wrong
It changed `staging.storageClassName`, on the theory that the staged clone's placement raced the mover pod. But staged clones on the default `longhorn` class already get all-3-node affinity, so staging could never wedge the scheduler. Dropped — onedr0p doesn't set `staging.storageClassName` either, so this also keeps us aligned with their component.

## Post-merge step (manual, one-time)
The existing `kopiur-cache-actual` PVC is still on `openebs-hostpath`, and a PVC's `storageClassName` is immutable — kopiur can't migrate it in place. It's pure cache, safe to drop:
```
kubectl delete pvc kopiur-cache-actual -n default
```
kopiur recreates it on `longhorn-cache` on the next run.

## Test plan
- [x] All components + `kopiur-system` build; rendered `SnapshotPolicy`/`SnapshotSchedule`/`Restore`/`ClusterRepository` validate against the kopiur 0.8.1 CRD schemas (verified locally)
- [ ] After merge + PVC deletion: `kubectl kopiur snapshot now --policy actual -n default --wait` succeeds
- [ ] New `kopiur-cache-actual` PV shows node affinity for all 3 nodes (not a single node)
- [ ] The next *scheduled* run completes without `MoverPodWedged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)