### PR TITLE
feat(actual): drop volsync, restore via kopiur

### DIFF
--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/restore
     - ../../../../components/zeroscaler
   dependsOn:
     - name: kopiur-repository
@@ -20,7 +20,6 @@ spec:
     substitute:
       APP: actual
       KOPIUR_CAPACITY: 2Gi
-      VOLSYNC_CAPACITY: 2Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/components/kopiur/restore/pvc.yaml
+++ b/kubernetes/components/kopiur/restore/pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${APP}
+  labels:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   accessModes:
     - ${KOPIUR_ACCESSMODES:=ReadWriteOnce}

--- a/kubernetes/components/kopiur/restore/pvc.yaml
+++ b/kubernetes/components/kopiur/restore/pvc.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${APP}
-  labels:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   accessModes:
     - ${KOPIUR_ACCESSMODES:=ReadWriteOnce}


### PR DESCRIPTION
## Summary
Completes `actual`'s migration: swaps `components/volsync` for `components/kopiur/restore`, so kopiur's `Restore` populator owns the volume and VolSync is gone for this app. Net diff is two lines, matching onedr0p's own cutover shape.

Backups have run on kopiur since #6148; after #6154 fixed the mover cache, four consecutive snapshots succeeded across **all three nodes** (`k8s-0`, `k8s-2`, `k8s-0`, `k8s-1`) — previously only `k8s-1` could ever schedule.

## Restore verified before committing to this
A PVC's `dataSourceRef` is immutable once bound — confirmed by server-side dry-run that an in-place swap is rejected:
```
spec: Forbidden: spec is immutable after creation except resources.requests
and volumeAttributesClassName for bound claims
```
So this follows onedr0p's approach: delete the PVC and let the kopiur populator rebuild it. (Their `rmrf volsync` → `kopiur go brr` commits are two minutes apart, with no component declaring the PVC in between — Flux pruned it and kopiur repopulated it from the snapshots they'd taken that morning. Their PVCs were never patched, just rebuilt with the kopiur populator from birth. That's why their component needs no `ssa: IfNotPresent` label, and neither does ours.)

Since that's destructive, I proved the restore path first — restored the latest snapshot to a **scratch** PVC and diffed it against the live volume:

| File | Live | Restored |
|---|---|---|
| `.migrate` | `de54f692…` | `de54f692…` |
| `server-files/account.sqlite` | `6dba9cbc…` | `6dba9cbc…` |
| `user-files/file-3fe1f917….blob` | `5eb2e21e…` | `5eb2e21e…` |
| `user-files/group-1f4c4c2b….sqlite` | `0c097720…` | `0c097720…` |

All four md5s identical, and snapshot stats (`filesNew: 4, sizeBytes: 124864`) match the live data byte-for-byte. Scratch PVC/Restore/pod cleaned up afterwards.

## What Flux prunes
`ReplicationSource/actual`, `ReplicationDestination/actual-dst`, `ExternalSecret/actual-volsync` + its Secret, and VolSync's own two PVCs (`volsync-actual-dst-dest` staging, `volsync-src-actual-cache`). None hold live app data.

The app's data PVC is declared by **both** components under the same name, so it stays in Flux's inventory and is never pruned by this change — it has to be deleted deliberately (see below).

## Cutover runbook (post-merge, manual — I'll run it)
1. Scale `actual` down so the DB is quiesced
2. Take a final kopiur snapshot of the stopped app (clean, not crash-consistent)
3. Delete PVC `actual` → Flux recreates it with `dataSourceRef` → `Restore`, populator hydrates from that snapshot
4. Scale back up, verify checksums against the values above

Rollback if the populator misbehaves: VolSync's snapshots are still in the same kopia repo, and `git revert` restores the VolSync component.

## Test plan
- [x] Server-side dry-run confirms the in-place swap is rejected (hence delete+repopulate)
- [x] Scratch restore from the latest snapshot matches live data on all four md5s
- [x] Rendered manifests build; VolSync objects to be pruned enumerated and confirmed data-free
- [ ] Post-merge: PVC recreated with the kopiur populator and app returns healthy with matching checksums
- [ ] Next scheduled snapshot succeeds against the repopulated PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)