### PR TITLE
chore(renovate): group talos installer with factory schematic

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,7 +6,7 @@ metadata:
   name: talos
 spec:
   talos:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
     version: v1.13.7
   policy:
     rebootMode: powercycle


### PR DESCRIPTION
## Problem

Renovate raised **two separate PRs** for the same Talos v1.13.8 bump:

- #6213 `renovate/ghcr.io-siderolabs-installer-1.x` — bumps `talosupgrade.yaml` only
- #6205 `renovate/talos` — created before #6212 merged, bumps both files

The `talos` package rule adopted in #6212 groups on `matchPackageNames: ["siderolabs/talos"]` with `minimumGroupSize: 2`, but only one of the repo's two Talos version references resolved to that package name:

| Reference | Resolved to |
|---|---|
| `talos/machineconfig.yaml.j2:51` — `factory.talos.dev/metal-installer/<schematic>:v1.13.7` | `siderolabs/talos` via `custom.talos-factory` ✅ |
| `kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml:9` | `ghcr.io/siderolabs/installer` on `docker` ❌ |

The group could never reach size 2, so the installer dep split off on its own and the two references could drift apart.

## Fix

Point the tuppr annotation at the same name and datasource the factory image already produces:

```diff
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
     version: v1.13.7
```

The preset's `managers/annotated.json5` scans all files and honours an explicit `datasource=`, so the annotated dep is emitted as `siderolabs/talos` on `custom.talos-factory` — matching the factory image. Both then land in one grouped PR.

## Matches upstream

`home-operations/onedr0p-home-ops` uses this exact annotation, and their merged group PRs touch precisely these two files:

```
9c46b802e8 feat(container): update talos group ( v1.12.7 ➔ v1.13.0 ) (#10795)
  kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
  talos/machineconfig.yaml.j2
```

No other Renovate changes are needed for parity — `kubernetesupgrade.yaml` and the talos group rule already match upstream.

## Verification

```
$ npx --yes --package renovate@44.13.1 renovate-config-validator --strict .renovaterc.json5
INFO: Config validated successfully against 1 file(s)
```

The validator does not fetch remote presets, so it cannot catch a datasource-name typo — confirm on the dependency dashboard after merge that both deps report under `siderolabs/talos`.

## Follow-up

Close #6205 and #6213 rather than merging: #6205 predates #6212, #6213 is the split half. Renovate should regenerate a single grouped PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)