### PR TITLE
fix(coredns): answer AAAA with NODATA on an IPv4-only cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
       repository: mirror.gcr.io/coredns/coredns
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
+    priorityClassName: system-cluster-critical
     serviceAccount:
       create: true
     service:
@@ -27,6 +28,10 @@ spec:
             use_tcp: true
         port: 53
         plugins:
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
           - name: errors
           - name: health
             configBlock: |-
@@ -45,6 +50,7 @@ spec:
             configBlock: |-
               prefetch 20
               serve_stale
+              servfail 0
           - name: loop
           - name: reload
           - name: loadbalance


### PR DESCRIPTION
Adopts `onedr0p/home-ops`'s CoreDNS `template` plugin, which answers every AAAA query with an authoritative NODATA. After this, `kubernetes/apps/kube-system/coredns` is identical to upstream.

## Why

The cluster is IPv4-only — `cilium enable-ipv6: false`, no IPv6 on nodes or pods — but cluster DNS still hands out AAAA records for external names. Anything that dials one gets `ENETUNREACH`. Verified from a pod:

```
dig AAAA pkg-containers.githubusercontent.com → 2606:50c0:8000::154, ::8002::154, ::8001::154
nc -6 2606:50c0:8002::154 443                 → Network unreachable
curl (default)                                 → 185.199.109.154, HTTP 400, 34ms
```

This is what has been breaking konflate renders. On #6216 it produced 14 failures, every one of the form `oras copy oci://… dial tcp [2606:50c0:…]:443: connect: network is unreachable`, hit whenever a chart is not already in konflate's cache. Over the last 10 days: 298 renders clean, 6 with 2 failures each, 1 with 14 — the count tracks how many uncached charts a render has to pull, not anything about the PR being rendered.

## What changes

- `template ANY AAAA` returning an authoritative NODATA, so no client in the cluster is handed an address family it cannot route. Nothing is lost: there is no IPv6 egress at all.
- `priorityClassName: system-cluster-critical` on the DNS pods.
- `servfail 0` in the cache block, so a failed lookup is not cached for 5s.

The last two are the other deltas that ship alongside it upstream.

## Validation

`helm template` against coredns 1.47.0 with these values renders the expected Corefile, with `{{ .Zone }}` passed through intact for the CoreDNS template plugin (the chart does not run `configBlock` through `tpl`):

```
dns://.:53 {
    template ANY AAAA {
        authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
    }
    errors
    ...
    cache {
        prefetch 20
        serve_stale
        servfail 0
    }
```

`kustomize build` clean on the app directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)