### PR TITLE
feat(frigate): add frigate with openvino gpu detection

### DIFF
--- a/kubernetes/apps/home/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home/frigate/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: frigate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: frigate-secret
+    template:
+      data:
+        FRIGATE_RTSP_USER: "{{ .RTSP_USERNAME }}"
+        FRIGATE_RTSP_PASSWORD: "{{ .RTSP_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: reolink

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -1,0 +1,298 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frigate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: frigate
+  interval: 1h
+  values:
+    controllers:
+      frigate:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
+            env:
+              TZ: America/Santiago
+              LIBVA_DRIVER_NAME: iHD
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: &port 5000
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              # Frigate's s6 supervisor needs to start as root and drop privileges itself
+              allowPrivilegeEscalation: false
+              capabilities: {add: ["PERFMON"]} # intel_gpu_top stats
+            resources:
+              claims:
+                - name: gpu
+              requests:
+                cpu: 500m
+              limits:
+                memory: 4Gi
+    defaultPodOptions:
+      affinity:
+        podAntiAffinity:
+          # Both apps claim the single iGPU of whichever node they land on, so keep
+          # detection off the node that is transcoding
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                namespaces: ["media"]
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: plex
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: frigate
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+          go2rtc:
+            port: 1984
+          rtsp:
+            port: 8554
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            path: /api/version
+        hostnames:
+          - "{{ .Release.Name }}.blkh.dev"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    configMaps:
+      config:
+        data:
+          config.yml: |-
+            mqtt:
+              enabled: true
+              host: mosquitto.home.svc.cluster.local
+              port: 1883
+              client_id: frigate
+              topic_prefix: frigate
+
+            detectors:
+              ov:
+                type: openvino
+                device: GPU
+
+            model:
+              width: 300
+              height: 300
+              input_tensor: nhwc
+              input_pixel_format: bgr
+              path: /openvino-model/ssdlite_mobilenet_v2.xml
+              labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+
+            ffmpeg:
+              hwaccel_args: preset-vaapi
+
+            detect:
+              enabled: true
+              fps: 5
+
+            objects:
+              track:
+                - person
+                - car
+                - dog
+                - cat
+
+            record:
+              enabled: true
+              continuous:
+                days: 0
+              motion:
+                days: 0
+              alerts:
+                retain:
+                  days: 14
+              detections:
+                retain:
+                  days: 7
+
+            snapshots:
+              enabled: true
+              retain:
+                default: 14
+
+            go2rtc:
+              streams:
+                backyard:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.238:554/h264Preview_01_main
+                backyard_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.238:554/h264Preview_01_sub
+                backyard_pool:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.42:554/h264Preview_01_main
+                backyard_pool_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.42:554/h264Preview_01_sub
+                entrance:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_main
+                entrance_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_sub
+                living_room:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.231:554/h264Preview_01_main
+                living_room_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.231:554/h264Preview_01_sub
+                family_room:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.84:554/h264Preview_01_main
+                family_room_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.84:554/h264Preview_01_sub
+                service_yard:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.146:554/h264Preview_01_main
+                service_yard_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.146:554/h264Preview_01_sub
+
+            cameras:
+              backyard:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/backyard
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/backyard_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: backyard
+                    Sub: backyard_sub
+              backyard_pool:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/backyard_pool
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/backyard_pool_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: backyard_pool
+                    Sub: backyard_pool_sub
+              entrance:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/entrance
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/entrance_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: entrance
+                    Sub: entrance_sub
+              living_room:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/living_room
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/living_room_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: living_room
+                    Sub: living_room_sub
+              family_room:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/family_room
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/family_room_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: family_room
+                    Sub: family_room_sub
+              service_yard:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/service_yard
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/service_yard_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: service_yard
+                    Sub: service_yard_sub
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+      media:
+        existingClaim: frigate-media-nfs
+        globalMounts:
+          - path: /media/frigate
+      cache:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /tmp/cache
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 256Mi
+        globalMounts:
+          - path: /dev/shm

--- a/kubernetes/apps/home/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home/frigate/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./nfs-media.yaml
+  - ./ocirepository.yaml
+  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/home/frigate/app/nfs-media.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-media.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: frigate-media-nfs
+spec:
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  mountOptions:
+    - nfsvers=3
+    - soft
+    - nolock
+    - timeo=30
+    - retrans=3
+    - noatime
+    - nconnect=8
+    - rsize=1048576
+    - wsize=1048576
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: frigate-media-nfs
+    volumeAttributes:
+      server: black-station.internal
+      share: /volume1/frigate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-media-nfs
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Mi
+  volumeName: frigate-media-nfs

--- a/kubernetes/apps/home/frigate/app/ocirepository.yaml
+++ b/kubernetes/apps/home/frigate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: frigate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/frigate/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/home/frigate/app/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: frigate
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: frigate
+  namespace: home
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: csi-driver-nfs
+      namespace: kube-system
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+    - name: longhorn
+      namespace: longhorn-system
+    - name: mosquitto
+      namespace: home
+  interval: 1h
+  path: ./kubernetes/apps/home/frigate/app
+  postBuild:
+    substitute:
+      APP: frigate
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./esphome/ks.yaml
+  - ./frigate/ks.yaml
   - ./go2rtc/ks.yaml
   - ./home-assistant/ks.yaml
   - ./matter-server/ks.yaml


### PR DESCRIPTION
Adds Frigate to the `home` namespace with the six Reolink cameras, doing object detection on the Intel iGPU via the [OpenVINO detector](https://docs.frigate.video/configuration/object_detectors/#openvino-detector).

## Hardware fit

OpenVINO requires 6th gen Intel (Skylake) or newer. All three nodes are 8th gen with a Gen9.5 iGPU, `i915` loaded and the device already published through DRA:

| Node | CPU | iGPU |
|---|---|---|
| k8s-0 | i7-8550U | UHD 620 (`0x5917`) |
| k8s-1 | i7-8550U | UHD 620 (`0x5917`) |
| k8s-2 | i7-8559U | Iris Plus 655 (`0x3ea5`) |

No NPU (Core Ultra only), so the docs' "NPU for detection, GPU for enrichment" split doesn't apply. RF-DETR is out — it needs Xe or Arc — so this starts on the bundled SSDLite MobileNet v2 model. YOLOv9 is the upgrade path but needs the model downloaded into `/config/model_cache`.

## Layout

Follows the existing app conventions — `ks.yaml` + `app/` with `helmrelease.yaml`, `ocirepository.yaml` (app-template 5.0.1), `externalsecret.yaml`, and, borrowing from `media/plex`, a `resourceclaimtemplate.yaml` for the GPU and an `nfs-media.yaml` PV/PVC for recordings.

- **GPU:** claimed via the `gpu.intel.com` device class from `intel-gpu-resource-driver`, same as plex.
- **Anti-affinity:** preferred pod anti-affinity against plex in `media`. Each node publishes one GPU device with `allowMultipleAllocations` unset, so DRA already prevents the two from sharing a GPU — this is belt-and-braces for CPU/RAM separation, and `preferred` so it can't leave Frigate `Pending` during Talos rolling upgrades.
- **Streams:** Frigate's built-in go2rtc connects directly to the cameras. The standalone `go2rtc` app stays as-is for Home Assistant's WebRTC dashboards. Routing Frigate through it wouldn't reduce camera connections — go2rtc connects only while a consumer is attached, and Frigate is a permanent 24/7 consumer of two streams per camera — and it would make detection and recording depend on a pod that restarts on every renovate bump.
- **Storage:** `/config` on longhorn with volsync (10Gi); `/media/frigate` on NFS (`/volume1/frigate`); `/tmp/cache` and `/dev/shm` as memory-medium emptyDirs.
- **Security context:** unlike other apps here, Frigate's s6 supervisor must start as root, so no `runAsNonRoot`. It is *not* privileged though — DRA/CDI injects `/dev/dri`, so only `PERFMON` is added, for `intel_gpu_top` stats.
- **Credentials:** RTSP creds come from the same `reolink` 1Password item go2rtc uses, injected as `FRIGATE_RTSP_USER`/`FRIGATE_RTSP_PASSWORD` and substituted into the config.

## Validation

- `kustomize build` passes on `apps/home/frigate/app` and `apps/home`
- `helm template` against app-template 5.0.1 renders cleanly; the embedded Frigate config parses as YAML with all 6 cameras and 12 go2rtc streams
- `kubectl apply --dry-run=server` accepts every object
- `0.17.2@sha256:d4351369…` verified as current `stable` on ghcr

## Notes

- Config is mounted read-only from a ConfigMap, so mask/zone edits in the Frigate UI won't persist — those changes belong in git.
- Camera RTSP paths use the Reolink `h264Preview_01_main` / `_sub` convention across all six. The fleet is mixed (RLC-810A, RLC-510WA, E1 Pro, Duo 2 PoE) and the dual-lens Duo 2 may need `h265Preview_01_main` or a `_02_` channel; to be confirmed against the live cameras.
- Retention starts conservative: 14d alerts, 7d detections, no continuous recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
