### PR TITLE
feat(ci): publish yolov9 onnx models as an oci image

### DIFF
--- a/.github/workflows/yolov9-model.yaml
+++ b/.github/workflows/yolov9-model.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: YOLOv9 Model
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to publish, following the repo YYYY.M.PATCH convention
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    name: YOLOv9 Model
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./docker/yolov9-onnx
+          platforms: linux/amd64
+          push: true
+          # Keep the manifest a plain single image rather than an index carrying
+          # attestations, since this is consumed as a Kubernetes image volume
+          provenance: false
+          sbom: false
+          tags: ghcr.io/${{ github.repository_owner }}/yolov9-onnx:${{ inputs.tag }}

--- a/docker/yolov9-onnx/Dockerfile
+++ b/docker/yolov9-onnx/Dockerfile
@@ -1,0 +1,44 @@
+# Exports YOLOv9 to ONNX for Frigate's OpenVINO detector and ships the result as a
+# scratch image, so it can be mounted read-only through a Kubernetes image volume
+# instead of being copied into Frigate's config PVC by hand.
+#
+# Follows Frigate's documented export recipe:
+# https://docs.frigate.video/configuration/object_detectors/#openvino-detector
+#
+# All three variants are built at 320x320. Frigate is optimised for 320 models — it
+# crops a motion region and zooms in before inference — so 640 is not worth the cost
+# here. Shipping t, s and m together makes switching variants a config change rather
+# than a rebuild.
+FROM python:3.11 AS build
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y cmake libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.10.4 /uv /bin/
+
+WORKDIR /yolov9
+ADD https://github.com/WongKinYiu/yolov9.git .
+
+# CPU-only torch ahead of requirements.txt, which would otherwise pull the CUDA build
+# and roughly 2GB of wheels this export never touches
+RUN uv pip install --system --index-url https://download.pytorch.org/whl/cpu torch torchvision
+# yolov9 predates numpy 2
+RUN uv pip install --system "numpy<2"
+RUN uv pip install --system -r requirements.txt
+RUN uv pip install --system onnx==1.18.0 onnxruntime onnx-simplifier==0.4.* onnxscript
+
+# torch 2.6 flipped torch.load to weights_only=True, which cannot load these checkpoints
+RUN sed -i "s/ckpt = torch.load(attempt_download(w), map_location='cpu')/ckpt = torch.load(attempt_download(w), map_location='cpu', weights_only=False)/g" models/experimental.py
+
+ARG IMG_SIZE=320
+RUN mkdir /out \
+    && for SIZE in t s m; do \
+         curl -sSLo "yolov9-${SIZE}.pt" \
+           "https://github.com/WongKinYiu/yolov9/releases/download/v0.1/yolov9-${SIZE}-converted.pt" \
+         && python3 export.py --weights "./yolov9-${SIZE}.pt" --imgsz "${IMG_SIZE}" --simplify --include onnx \
+         && mv "yolov9-${SIZE}.onnx" "/out/yolov9-${SIZE}-${IMG_SIZE}.onnx"; \
+       done
+
+FROM scratch
+COPY --from=build /out/ /


### PR DESCRIPTION
**Step 1 of 2.** This PR only adds the build; nothing is deployed. The Frigate config that consumes it is #6223, which must not merge until the image exists and the mount is smoke-tested.

## Why CI and not a Job or init container

Frigate ships no YOLOv9 model and there's no auto-download — the ONNX has to be produced and placed on a readable path. Every option that avoids CI leaves state git can't see:

- **One-shot Job** → untracked blob in the longhorn config PVC. Nothing in the repo explains how it got there, and a fresh cluster or volsync restore silently loses it.
- **Init container** → either re-runs a multi-GB torch build on every pod start, or downloads from a URL that doesn't exist.
- **Committing the binaries** (as some repos do) → every clone and every Flux `GitRepository` fetch carries ~120MB forever.

Building once and publishing to GHCR lets the cluster mount the result read-only via a Kubernetes image volume: model version in git, nothing mutable in the PVC, reproducible on a rebuild.

## What it builds

`docker/yolov9-onnx/Dockerfile` follows Frigate's [documented export recipe](https://docs.frigate.video/configuration/object_detectors/#openvino-detector), producing `yolov9-{t,s,m}-320.onnx` into a `FROM scratch` image.

- **320x320, not 640** — Frigate crops a motion region and zooms in before inference, so a 320 model is *better* at small and distant objects, and 640's only real gain is fitting many spread-out objects into one inference.
- **All three variants in one image** — switching from `s` to `m` later is a one-line `model.path` edit, no rebuild and no re-pull.
- **CPU-only torch installed ahead of `requirements.txt`**, which would otherwise drag in the CUDA build and ~2GB of wheels the export never touches. `numpy<2` pinned because yolov9 predates it.
- The `weights_only=False` sed is from the upstream recipe — torch 2.6 flipped that default and these checkpoints can't load without it.

A plain image rather than an OCI artifact, with `provenance`/`sbom` off, so the manifest stays a single image rather than an index carrying attestations — image volumes are better behaved that way.

## Notes

- The models are **generic**: stock COCO weights from `yolov9-{t,s,m}-converted.pt` (all three release assets verified reachable). Nothing camera-specific, so the GHCR package can be public like this repo.
- `workflow_dispatch` only, with a `tag` input following the repo's `YYYY.M.PATCH` convention. This rebuilds a handful of times ever, so a push trigger would just burn minutes.
- After the first run, the GHCR package needs to be marked public so nodes can pull without a secret.

## Validation

Workflow parses, and `zizmor` reports no findings. Actions pinned by commit SHA with version comments, matching the convention in `image-pull.yaml` and `tag.yaml`.

The build itself is unproven until the first dispatch — it's a ~15 minute torch export, and the upstream recipe is the only reference for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)