### PR TITLE
feat(frigate): switch detection to yolov9-s via an oci image volume

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -7,6 +7,15 @@
     commitMessageExtra: "({{manager}})",
     additionalBranchPrefix: "{{manager}}-",
   },
+  customManagers: [
+    {
+      description: "YOLOv9 ONNX image volume reference (not a field the flux manager sees)",
+      customType: "regex",
+      managerFilePatterns: ["kubernetes/apps/home/frigate/app/helmrelease.yaml"],
+      matchStrings: ["reference:\\s+(?<depName>ghcr\\.io/[^\\s:]+):(?<currentValue>\\S+)"],
+      datasourceTemplate: "docker",
+    },
+  ],
   packageRules: [
     // Auto-merge rules
     {

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -122,13 +122,16 @@ spec:
                 type: openvino
                 device: GPU
 
+            # Mounted read-only from the yolov9-onnx image volume. t, s and m are all
+            # in that image, so trying another variant is a path change here.
             model:
-              width: 300
-              height: 300
-              input_tensor: nhwc
-              input_pixel_format: bgr
-              path: /openvino-model/ssdlite_mobilenet_v2.xml
-              labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+              model_type: yolo-generic
+              width: 320
+              height: 320
+              input_tensor: nchw
+              input_dtype: float
+              path: /models/yolov9-s-320.onnx
+              labelmap_path: /labelmap/coco-80.txt
 
             ffmpeg:
               hwaccel_args: preset-vaapi
@@ -284,6 +287,17 @@ spec:
         existingClaim: frigate-media-nfs
         globalMounts:
           - path: /media/frigate
+      # Deliberately not under /config/model_cache: this mount is read-only and
+      # Frigate writes its compiled OpenVINO blob into model_cache
+      models:
+        type: custom
+        volumeSpec:
+          image:
+            reference: ghcr.io/blackjid/yolov9-onnx:1.0.0
+            pullPolicy: IfNotPresent
+        globalMounts:
+          - path: /models
+            readOnly: true
       cache:
         type: emptyDir
         medium: Memory


### PR DESCRIPTION
Standalone against `main` — independent of #6219, which can be merged, changed, or dropped without affecting this.

## What changes

Detection moves from the bundled SSDLite MobileNet v2 to yolov9-s at 320x320. SSDLite is the weakest model available and confuses dogs and cats routinely. YOLOv9 is the best this hardware can run — RF-DETR needs an Xe iGPU or Arc, and D-FINE/DEIMv2 only compile for CPU, which would mean giving up the iGPU.

The model arrives as a **read-only image volume** from `ghcr.io/blackjid/yolov9-onnx:1.0.0` (built by #6220), not as a blob copied into the config PVC. `ImageVolume` is GA on this v1.36.3 cluster and containerd is 2.2.6.

Mounted at `/models`, deliberately **not** under `/config/model_cache` — that mount is read-only and Frigate writes its compiled OpenVINO blob into `model_cache`.

All three variants (`t`, `s`, `m`) ship in the one image, so trying a different size later is a one-line `model.path` edit — no rebuild, no re-pull.

The `detectors:` block is unchanged; this is purely a model swap. Recording, camera inputs and tracked-object lists are untouched here.

## Label map

`labelmap_path` moves from COCO-91 to COCO-80, which shifts label *indices*. The `objects.track` list uses names rather than indices so it needs no change — but that shift is exactly why `labelmap_path` has to be set explicitly.

## Renovate

Renovate's flux manager doesn't see a `reference:` field inside HelmRelease values, so `.renovaterc.json5` gets a custom manager for it. Referenced by **tag, not digest** — `ImageVolumeWithDigest` is alpha and disabled on this cluster (`kubernetes_feature_enabled{name="ImageVolumeWithDigest",stage="ALPHA"} 0`).

## Merge checklist

The Frigate controller uses `strategy: Recreate` (required by the RWO longhorn config PVC), so the old pod is terminated *before* the new one starts. A failed volume mount means Frigate stays down until this is reverted.

1. [ ] **YOLOv9 Model** workflow dispatched with tag `1.0.0`, GHCR package marked public
2. [ ] Image volume smoke-tested with a throwaway pod:
   ```
   kubectl run imgvol-test --rm -it --restart=Never --image=busybox \
     --overrides='{"spec":{"volumes":[{"name":"m","image":{"reference":"ghcr.io/blackjid/yolov9-onnx:1.0.0","pullPolicy":"IfNotPresent"}}],"containers":[{"name":"t","image":"busybox","command":["ls","-la","/models"],"volumeMounts":[{"name":"m","mountPath":"/models","readOnly":true}]}]}}'
   ```
   Expect three `.onnx` files. If this fails, stop — merging would take Frigate down.
3. [ ] Then merge

## After merge

- The first boot is slow while OpenVINO compiles the ONNX for the GPU and caches the blob — **the initial `inference_speed` is not representative**.
- `curl -sk https://frigate.blkh.dev/api/stats | jq '.detectors'` — expect roughly 15–25ms versus the 6.7ms SSDLite baseline.
- `curl -sk https://frigate.blkh.dev/api/stats | jq '.cameras|map({camera:.key,skipped_fps:.value.skipped_fps})'` — `skipped_fps` must stay 0 across all six. Non-zero means drop `model.path` to `yolov9-t-320.onnx`; if there's plenty of headroom, `yolov9-m-320.onnx` is worth trying.
- `kubectl -n home exec deploy/frigate -- find /config/model_cache -type f` — confirms the compiled cache landed somewhere writable. If it's empty and the logs show a write error against `/models`, the cache-directory assumption is wrong and the model has to live on the PVC after all.

Note this branch still carries the six main streams with `record` roles, so the `living_room`/`family_room` RTSP timeout loop documented in #6219 persists independently of this change.

## Validation

`kustomize build` and `helm template` pass against `main`; the rendered Deployment carries the image volume with `readOnly: true` on the mount. `kubectl apply --dry-run=server` accepts it, which confirms the API server has `ImageVolume` enabled rather than just reporting the gate. `renovate-config-validator` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
