### PR TITLE
feat(frigate): enable semantic search and face recognition on the igpu

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -66,7 +66,9 @@ spec:
               requests:
                 cpu: 500m
               limits:
-                memory: 4Gi
+                # Enrichments load the jinav1 large + ArcFace models on top of the
+                # detector; upstream asks for 8GB minimum with semantic search on
+                memory: 8Gi
     defaultPodOptions:
       affinity:
         podAntiAffinity:
@@ -146,6 +148,22 @@ spec:
                 - car
                 - dog
                 - cat
+
+            # Enrichments share the same iGPU as the detector: OpenVINO picks it up
+            # automatically in the default image, so no device key is needed.
+            # Models are downloaded once into /config/model_cache on the config PVC.
+            semantic_search:
+              enabled: true
+              model: jinav1
+              model_size: large
+
+            face_recognition:
+              enabled: true
+              # 0.17.x ships OpenVINO 2025.3, which has a clCreateSubBuffer bug that
+              # crashes the embeddings manager for the large (ArcFace) model on Intel
+              # iGPUs. If embeddings_manager starts crash-looping, set `device: CPU`
+              # here, or drop to `model_size: small`, until 0.18 (OpenVINO 2025.4).
+              model_size: large
 
             record:
               enabled: true


### PR DESCRIPTION
Turns on both enrichments with the `large` models to see how much the iGPU can carry alongside yolov9-s detection.

## Changes

- `semantic_search` enabled — `model: jinav1`, `model_size: large`
- `face_recognition` enabled — `model_size: large`
- Memory limit 4Gi → 8Gi

No `device:` key on either. The default image auto-detects the Intel GPU for enrichments, and the pod already holds the iGPU through the existing `frigate` ResourceClaimTemplate, so enrichments land on the same GPU as detection. The memory bump is upstream's stated minimum with semantic search on, now that jinav1-large and ArcFace load next to the detector.

## Known issue with face recognition on this version

`v0.17.2` pins `openvino == 2025.3.*`, which has a `clCreateSubBuffer / CL_INVALID_VALUE` bug that crash-loops `embeddings_manager` for the large ArcFace model on Intel iGPUs — see [discussion #22236](https://github.com/blakeblackshear/frigate/discussions/22236). It's an OpenVINO bug rather than a Frigate one, fixed in 2025.4, which only lands in 0.18.

`large` is kept here deliberately, with the fallback recorded in a comment next to the setting: if the container crash-loops, either add `device: CPU` under `face_recognition` or drop to `model_size: small`. Semantic search large is unaffected.

## Rollout notes

- First start downloads ~1-2GB of enrichment models into `/config/model_cache`. Fits the 10Gi `VOLSYNC_CAPACITY` but will grow the volsync snapshots.
- `reindex` is left at `false`. Flipping it to `true` for one boot would backfill embeddings for every existing tracked object — a heavier iGPU test, but it needs flipping back afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)