### PR TITLE
feat(frigate): switch detection to yolov9-m to fix dog/cat confusion

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -132,7 +132,10 @@ spec:
               height: 320
               input_tensor: nchw
               input_dtype: float
-              path: /models/yolov9-s-320.onnx
+              # m over s to see whether the extra capacity fixes dogs being called
+              # cats. Fine-grained class discrimination is where the bigger variant
+              # earns its keep; revert to yolov9-s-320.onnx if the iGPU can't take it.
+              path: /models/yolov9-m-320.onnx
               labelmap_path: /labelmap/coco-80.txt
 
             ffmpeg:


### PR DESCRIPTION
The COCO detector has been labelling one of the dogs as a cat. Trying the next model variant up before reaching for anything heavier.

## Change

`model.path`: `/models/yolov9-s-320.onnx` → `/models/yolov9-m-320.onnx`

That's the whole diff. `m` already ships in `ghcr.io/blackjid/yolov9-onnx:1.0.0` alongside `t` and `s` — verified the file is there, 80MB vs `s` at 28.5MB — so this is a path change, not a rebuild.

## Why this and not a resolution bump

Input stays at 320. Frigate crops the motion region and scales it up before inference, so a larger model input mostly buys interpolated pixels rather than real detail — the reasoning already recorded in `docker/yolov9-onnx/dockerfile`. The extra parameters in `m` go to fine-grained class discrimination instead, which is exactly where the dog/cat boundary sits.

## Why not custom classification

Worth recording so we don't revisit it: 0.17's [object classification](https://docs.frigate.video/configuration/custom_classification/object_classification/) can't fix this. It only runs on objects the detector already labelled correctly and writes to `sub_label` or an attribute, never the primary label — so on a box the detector called `cat`, a classifier keyed on `dog` never fires. Correcting the primary label properly means [Frigate+](https://docs.frigate.video/plus/) retraining, which is the fallback if `m` doesn't help.

## Watch after deploy

`m` is ~2.8x the model size of `s`, and #6228 just put jinav1-large and ArcFace on the same iGPU. If detection latency climbs or the GPU saturates, revert the path to `yolov9-s-320.onnx` — the comment next to the setting says so.

Object filters on `cat` (`min_score` / `threshold`) are the other lever, deliberately left out of this PR to keep one variable in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)