### PR TITLE
fix(frigate): revert to yolov9-s, correct camera names, disable family_room

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -132,10 +132,11 @@ spec:
               height: 320
               input_tensor: nchw
               input_dtype: float
-              # m over s to see whether the extra capacity fixes dogs being called
-              # cats. Fine-grained class discrimination is where the bigger variant
-              # earns its keep; revert to yolov9-s-320.onnx if the iGPU can't take it.
-              path: /models/yolov9-m-320.onnx
+              # Back to s: m ran 70-76ms per inference, so at ~14 detections/sec the
+              # detector was at ~100% duty cycle and Frigate was dropping ~3fps of
+              # frames it never got to look at. The dog/cat confusion m was meant to
+              # fix needs Frigate+ retraining instead, not a bigger COCO detector.
+              path: /models/yolov9-s-320.onnx
               labelmap_path: /labelmap/coco-80.txt
 
             ffmpeg:

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -291,6 +291,13 @@ spec:
                     Main: living_room
                     Sub: living_room_sub
               family_room:
+                # Stopgap: 192.168.20.84 drops off the network intermittently, and
+                # Frigate's reconnect loop burns ~0.75 cores producing 0 fps while it
+                # does. The camera itself answers when probed directly, so this is a
+                # link fault to chase at the camera, not here. Flip back to true once
+                # it holds a connection; the go2rtc streams below stay defined so
+                # that is the only change needed.
+                enabled: false
                 ffmpeg:
                   inputs:
                     - path: rtsp://127.0.0.1:8554/family_room

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -189,18 +189,28 @@ spec:
 
             go2rtc:
               streams:
-                backyard:
+                # 192.168.20.238 is HA's "Quincho Fluent" — it was called backyard
+                # here, which left the actual backyard camera without the name
+                quincho:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.238:554/h264Preview_01_main
-                backyard_sub:
+                quincho_sub:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.238:554/h264Preview_01_sub
+                # 192.168.20.223 is HA's "Greengarden Fluent", area Backyard. It was
+                # configured as entrance, so entrance pointed at the wrong garden
+                backyard:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_main
+                backyard_sub:
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_sub
                 backyard_pool:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.42:554/h264Preview_01_main
                 backyard_pool_sub:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.42:554/h264Preview_01_sub
+                # The real entrance: Reolink Duo 2 PoE, dual lens stitched into one
+                # ultra-wide frame (main 4608x1728 HEVC, sub 1536x576 h264)
                 entrance:
-                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_main
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.250:554/h264Preview_01_main
                 entrance_sub:
-                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.223:554/h264Preview_01_sub
+                  - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.250:554/h264Preview_01_sub
                 living_room:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.231:554/h264Preview_01_main
                 living_room_sub:
@@ -215,6 +225,19 @@ spec:
                   - rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@192.168.20.146:554/h264Preview_01_sub
 
             cameras:
+              quincho:
+                ffmpeg:
+                  inputs:
+                    - path: rtsp://127.0.0.1:8554/quincho
+                      input_args: preset-rtsp-restream
+                      roles: [record]
+                    - path: rtsp://127.0.0.1:8554/quincho_sub
+                      input_args: preset-rtsp-restream
+                      roles: [detect]
+                live:
+                  streams:
+                    Main: quincho
+                    Sub: quincho_sub
               backyard:
                 ffmpeg:
                   inputs:


### PR DESCRIPTION
Three fixes to the Frigate config, all found while looking into why the pod was sitting at **2716m CPU**. Together they should recover roughly **1.5–1.8 cores**.

## 1. Revert detection to yolov9-s

`yolov9-m` (merged in #6229) is too heavy for the iGPU. Measured on the running pod:

| | |
|---|---|
| `inference_speed` | **70–76 ms** |
| `detection_fps` | 12.4–13.9 |
| `skipped_fps` | **3.1** |
| `frigate.detector:ov` CPU | **80.9%** of a core |
| iGPU | 50% |

At ~14 detections/sec × 71 ms the detector is at roughly **100% duty cycle**, and `skipped_fps: 3.1` means frames were arriving faster than it could consume them — Frigate was dropping them unlooked-at. The previous commit anticipated exactly this and left the escape hatch; this takes it.

The dog-being-labelled-cat problem that motivated `m` is unfixed. That needs Frigate+ retraining rather than a heavier COCO detector, so it should be solved there instead of paying for `m`'s capacity on every frame.

## 2. The backyard and entrance cameras were misnamed, and the real entrance was missing

Cross-referencing the configured IPs against the Home Assistant camera entities:

- `entrance` → `192.168.20.223` → HA **"Greengarden Fluent"**, area **Backyard**. Pointed at the garden, not the entrance.
- `backyard` → `192.168.20.238` → HA **"Quincho Fluent"**. Holding the name the actual backyard camera needed.
- The real entrance camera was **not in the config at all**.

Everything shifts down one:

| IP | Before | After |
|---|---|---|
| 192.168.20.238 | `backyard` | `quincho` |
| 192.168.20.223 | `entrance` | `backyard` |
| 192.168.20.42 | `backyard_pool` | unchanged |
| **192.168.20.250** | — | **`entrance`** (new) |

The missing camera was found by sweeping `:554` across the subnet — `192.168.20.250` was the only device not already configured — and matching it to the Entrance-area device in HA. It is a Reolink Duo 2 PoE: dual lens stitched into one ultra-wide frame, main `4608x1728` HEVC, sub `1536x576` h264.

### Fallout

Renaming orphans the existing recordings and events under the old camera names, and moves the HA entity ids (`camera.entrance` → `camera.backyard`, `camera.backyard` → `camera.quincho`, plus the associated `binary_sensor.*`). Retention is 14 days so the history ages out on its own; the HA references are being fixed separately.

Note the new entrance camera's 8:3 aspect ratio is unusually wide — worth watching whether detection on small objects holds up once it's live, since the detect stream gets letterboxed into a square input.

## 3. Disable family_room until its link is stable

`192.168.20.84` drops off the network intermittently. go2rtc logs repeated `dial tcp 192.168.20.84:554: i/o timeout` on both its streams, and Frigate's reconnect loop spends **~0.75 cores** on it — 55.8% on ffmpeg plus 18.1% on `frigate.capture:family_room` — while reporting `camera_fps: 0.0`. It also floods the log with `Unable to read frames from ffmpeg process` several times a second.

The camera answers a direct `ffprobe` fine, so the fault is in the link rather than the camera or this config. This is a **stopgap, not a fix** — the physical link still needs chasing. The go2rtc entries stay defined, so re-enabling is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)