### PR TITLE
fix(renovate): bump home-operations presets to 7.0.0

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>home-operations/renovate-presets#5.0.0", ":timezone(America/Santiago)"],
+  extends: [
+    "github>home-operations/renovate-presets#7.0.0",
+    // App-specific presets are opt-in since 6.0.0
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#7.0.0",
+    ":timezone(America/Santiago)",
+  ],
   lockFileMaintenance: {
     enabled: true,
     schedule: ["before 3am on the first day of the month"],


### PR DESCRIPTION
Closes #6235

## Problem

Renovate stopped opening PRs with:

> Cannot find preset's package (github>home-operations/renovate-presets//config/baseConfig.json5)

The config pinned `github>home-operations/renovate-presets#5.0.0`. At that tag `default.json` was just a list of nested `extends` — and those nested references carry **no ref**, so Renovate resolves them against the preset repo's *default branch*, not the 5.0.0 tag. Pinning the tag never protected us here.

Upstream then restructured:

- **6.0.0** — app-specific presets moved to `apps/` and became opt-in
- **7.0.0** — general-purpose presets consolidated into a flat `default.json`, deleting `config/`, `managers/`, `overrides/`, `policies/`, `versioning/`

So `//config/baseConfig.json5` no longer exists on the default branch and resolution failed.

## Fix

Bump to `7.0.0` and re-add the two `apps/` presets this repo actually needs, each pinned to `7.0.0`:

| Preset | Why it's needed here |
| --- | --- |
| `apps/grafanaDashboards.json5` | 10+ `grafanadashboard.yaml` files, plus the `matchDatasources: ["custom.grafana-dashboards"]` automerge rule that would otherwise match nothing |
| `apps/talosFactory.json5` | Defines the `custom.talos-factory` datasource that `kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml` references by `# renovate:` annotation, and picks up the `factory.talos.dev` installer image in `talos/machineconfig.yaml.j2`. Together those are the two `siderolabs/talos` deps the `minimumGroupSize: 2` Talos Group needs to form. |

Skipped `cnpg`, `llamacpp`, `phanpy`, `searxng` — no matching resources in this repo.

## Verification

- `renovate-config-validator --strict` → *Config validated successfully*
- Extends block matches [onedr0p/home-ops](https://github.com/onedr0p/home-ops/blob/main/.renovaterc.json5) exactly (same three entries, same order, same tag; only the timezone differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)